### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "keywords"       : ["database", "keyvalue"],
   "author"         : "Peter 'Pita' Martischka <petermartischka@googlemail.com>",
   "dependencies"   : {
-                       "mysql"   : "0.9.4",
-                       "dirty"   : "0.9.4",
+                       "mysql"   : "0.9.5",
+                       "dirty"   : "0.9.6",
                        "async"   : "0.1.15",
                        "channels": "0.0.2"
                      },
   "devDependencies": {
-                       "log4js"  : "0.3.9"
+                       "log4js"  : "0.4.1"
                      },
   "main"           : "./CloneAndAtomicLayer",
-  "version"        : "0.1.5"
+  "version"        : "0.1.6"
 }


### PR DESCRIPTION
I updated the dependencies. This should remove the deprecation warning from `dirty`. Could you please update the npm version so we can change the dependency in etherpad-lite too?

Regards
Philipp
