### PR TITLE
Implemented findKeys for SQLite, updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ Look at sqlite_db.js and mysql_db.js, your module have to provide the same funct
 Only mysql, dirty and mongodb currently support findKeys feature. The following do not yet support the function:
 * couch
 * leveldb
-* postgres
 * redis
-* sqlite
 
 For details on how it works please refer to the wiki: https://github.com/Pita/ueberDB/wiki/findKeys-functionality
 

--- a/sqlite_db.js
+++ b/sqlite_db.js
@@ -77,6 +77,37 @@ exports.database.prototype.get = function (key, callback)
   });
 }
 
+exports.database.prototype.findKeys = function (key, notKey, callback)
+{
+  var query="SELECT key FROM store WHERE key LIKE ?"
+    , params=[]
+  ;
+  //desired keys are %key:%, e.g. pad:%
+  key=key.replace(/\*/g,'%');
+  params.push(key);
+  
+  if(notKey!=null && notKey != undefined){
+    //not desired keys are notKey:%, e.g. %:%:%
+    notKey=notKey.replace(/\*/g,'%');
+    query+=" AND key NOT LIKE ?"
+    params.push(notKey);
+  }
+  
+  this.db.all(query, params, function(err,results)
+  {
+    var value = [];
+    
+    if(!err && Object.keys(results).length > 0)
+    {
+      results.forEach(function(val){
+        value.push(val.key);
+      });
+    }
+  
+    callback(err,value);
+  });
+}
+
 exports.database.prototype.set = function (key, value, callback)
 {
   this.db.run("REPLACE INTO store VALUES (?,?)", key, value, callback);


### PR DESCRIPTION
This implementes `findKeys` for SQLite, it's basically the mysql-version with a few adaptions, it passes `node findKeysTest.js sqlite` so I'd say it works.
I've also updated `README.md` since `postgres` already supports `findKeys`.
