### PR TITLE
fixed dependency to use correct redis client

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
                        "dirty"     : "0.9.6",
                        "async"     : "0.1.15",
                        "channels"  : "0.0.2",
-                       "node-redis": "0.1.x"
+                       "redis"     : "0.8.2"
                      },
   "devDependencies": {
                        "log4js"  : "0.4.1",


### PR DESCRIPTION
Fixed this for redis, not sure why other dbms like mysql are not in this file.
