### PR TITLE
Add pg module to package.json as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
                      ],
   "dependencies"   : {
                        "mysql"     : "0.9.5",
+                       "pg"        : "0.14.1",
                        "dirty"     : "0.9.6",
                        "async"     : "0.1.15",
                        "channels"  : "0.0.2",


### PR DESCRIPTION
Etherpad-lite fails to run on Postgres out of the box because of this missing dependency.
