### PR TITLE
Adding Unix Socket connectivity for Redis.

### DIFF
--- a/redis_db.js
+++ b/redis_db.js
@@ -21,7 +21,7 @@ var redis = require("redis");
     {
       host: 
       port:
-      socket: * NOTE: if you're using Unix sockets, you don't need host or port in your settings.json
+      socket:
       database:
       password:
       client_options
@@ -47,12 +47,12 @@ exports.database.prototype.select = function(callback){
 }
 
 exports.database.prototype.init = function(callback) {
-  if (!this.settings.socket) {
-    this.client = redis.createClient(this.settings.port,
-    this.settings.host, this.settings.client_options);
-  } else {
+  if (this.settings.socket) {
     this.client = redis.createClient(this.settings.socket, 
     this.settings.client_options);
+  } else {
+    this.client = redis.createClient(this.settings.port,
+    this.settings.host, this.settings.client_options);
   }
   
   this.client.database = this.settings.database;


### PR DESCRIPTION
Added functionality to connect to a Redis server via Unix sockets.

I figure that since Redis does support the use of Unix sockets, it might not be a bad idea to add this connection functionality to UeberDB.

The change has been tested locally on my system and it worked.

If you need any more information from me about this pull request, feel free to let me know.
