### PR TITLE
Select only key field in mongo.find function (for findKeys)

### DIFF
--- a/mongodb_db.js
+++ b/mongodb_db.js
@@ -105,7 +105,7 @@ function MongoKeyValue(dbName, dbHost, dbPort, dbUser, dbPass, fncallback, colle
     this.find = function(key, callback) {
       me.db.collection(me.collectionName, function (err, collection) {
             if (err) callback(err);
-            var p = collection.find({ key: key }).toArray(function (err, ret) {
+            var p = collection.find({ key: key }, { _id:0, key: 1 }).toArray(function (err, ret) {
                 if (ret){
                     var keys=[];
                     ret.forEach(function(val){


### PR DESCRIPTION
If you don't select only the key field, you can exceed the maxBsonSize very fast in your response => you get a null response.

I get the problem with 1057 pads. Asking only for the key field made it works again.
