### PR TITLE
Allow configuring `cqlVersion` in Cassandra backend

### DIFF
--- a/cassandra_db.js
+++ b/cassandra_db.js
@@ -53,6 +53,7 @@ exports.database = function(settings) {
   self.settings.timeout = parseInt(settings.timeout, 10) || 3000;
   self.settings.replication = parseInt(settings.replication, 10) || 1;
   self.settings.strategyClass = settings.strategyClass || 'SimpleStrategy';
+  self.settings.cqlVersion = '2.0.0';
 };
 
 /**

--- a/defaultTestSettings.js
+++ b/defaultTestSettings.js
@@ -5,4 +5,4 @@ exports["dirty"] = {filename:"var/dirty.db"};
 exports["redis"] = {};
 exports["couch"] = {port: 5984, host: 'localhost', database: "etherpadlite", maxListeners: 0};
 exports["mongodb"] = {port: 27017, host: "localhost", dbname: "etherpadlite"};
-exports["cassandra"] = {hosts: ["127.0.0.1:9160"], keyspace: "etherpadlite", cfName: 'etherpadlite'};
+exports["cassandra"] = {hosts: ["127.0.0.1:9160"], keyspace: "etherpadlite", cfName: "etherpadlite"};


### PR DESCRIPTION
For `cassandra_db.js`, which can implicity be considered `cassandra_cql2_db.js` now, if you want to run CQL2 on Cassandra 1.2.x or higher, you'll want to be able to configure `cqlVersion: '2.0.0'`.

Coincidentally, the fact that helenus is being set to version `0.6.2` is leveraging a bug where helenus will default to CQL2 when connecting to Cassandra 1.2.x+. However, if helenus is upgraded to 0.6.3+, the driver will effectively be broken on Cassandra 1.2.x as-is. So this should be fixed before upgrading that module.
