### PR TITLE
Revert to pre- e8b58d0 state, fixes key search regression

### DIFF
--- a/mysql_db.js
+++ b/mysql_db.js
@@ -146,13 +146,12 @@ exports.database.prototype.get = function (key, callback)
 
 exports.database.prototype.findKeys = function (key, notKey, callback)
 {
-  var query="SELECT `key` FROM `store` WHERE `key` = ? AND BINARY `key` LIKE ?"
+  var query="SELECT `key` FROM `store` WHERE `key` LIKE ?"
     , params=[]
   ;
   
   //desired keys are key, e.g. pad:%
   key=key.replace(/\*/g,'%');
-  params.push(key);
   params.push(key);
   
   if(notKey!=null && notKey != undefined){


### PR DESCRIPTION
The equality/`=` search breaks the prefix/`LIKE` search

Note that the `BINARY` was not necessary to fix the trailing whitespace issue observed in ether/etherpad-lite#2877, as `LIKE` is not subject to the `PAD SPACE` behaviour in MySQL, see https://dev.mysql.com/doc/refman/5.6/en/char.html (search for `PAD SPACE`).

It furthermore seems to be good practice to keep the `BINARY` to force a case-sensitive comparison, as `LIKE` doesn't seem to have guarantees regarding case-sensitivity. As the key is a column with a binary collation `LIKE` searches are forced to be case-sensitive though, see https://dev.mysql.com/doc/refman/5.6/en/case-sensitivity.html, so no need to force `BINARY` here as long as the `key` column keeps a case-sensitive collation.

This search is also not affected by the speed regression and will use the primary key index and thus stay fast.