### PR TITLE
Fix slow doBulk()

### DIFF
--- a/mysql_db.js
+++ b/mysql_db.js
@@ -205,7 +205,6 @@ exports.database.prototype.doBulk = function (bulk, callback)
   var _this = this;
   
   var replaceSQL = "REPLACE INTO `store` VALUES ";
-  var removeSQL = "DELETE FROM `store` WHERE BINARY `key` IN ";
   
   // keysToDelete is a string of the form "(k1, k2, ..., kn)" painstakingly built by hand.
   let keysToDelete = "(";
@@ -236,7 +235,8 @@ exports.database.prototype.doBulk = function (bulk, callback)
   keysToDelete += ")";
 
   replaceSQL+=";";
-  removeSQL+= keysToDelete + ";";
+
+  var removeSQL = "DELETE FROM `store` WHERE BINARY `key` IN " + keysToDelete + ";";
   
   async.parallel([
     function(callback)

--- a/mysql_db.js
+++ b/mysql_db.js
@@ -205,8 +205,11 @@ exports.database.prototype.doBulk = function (bulk, callback)
   var _this = this;
   
   var replaceSQL = "REPLACE INTO `store` VALUES ";
-  var removeSQL = "DELETE FROM `store` WHERE BINARY `key` IN ("
+  var removeSQL = "DELETE FROM `store` WHERE BINARY `key` IN ";
   
+  // keysToDelete is a string of the form "(k1, k2, ..., kn)" painstakingly built by hand.
+  let keysToDelete = "(";
+
   var firstReplace = true;
   var firstRemove = true;
   
@@ -223,15 +226,17 @@ exports.database.prototype.doBulk = function (bulk, callback)
     else if(bulk[i].type == "remove")
     {
       if(!firstRemove)
-        removeSQL+=",";
+        keysToDelete+=",";
       firstRemove = false;
     
-      removeSQL+=_this.db.escape(bulk[i].key);
+      keysToDelete+=_this.db.escape(bulk[i].key);
     }
   }
   
+  keysToDelete += ")";
+
   replaceSQL+=";";
-  removeSQL+=");";
+  removeSQL+= keysToDelete + ";";
   
   async.parallel([
     function(callback)

--- a/mysql_db.js
+++ b/mysql_db.js
@@ -236,7 +236,7 @@ exports.database.prototype.doBulk = function (bulk, callback)
 
   replaceSQL+=";";
 
-  var removeSQL = "DELETE FROM `store` WHERE BINARY `key` IN " + keysToDelete + ";";
+  var removeSQL = "DELETE FROM `store` WHERE `key` IN " + keysToDelete + " AND BINARY `key` IN " + keysToDelete + ";";
   
   async.parallel([
     function(callback)


### PR DESCRIPTION
A recent change (df20d21a71cf) made the deletion core correct when db keys are utf8 characters, but introduced a performance regression.

That performance regression was (more or less) fixed in 7762f0096458, but that commit forgot to include the required change on bulkDelete(), too.

This change fixes that.