### PR TITLE
postgres: Use Postgres’ jsonb data type for efficience

### DIFF
--- a/databases/postgres_common.js
+++ b/databases/postgres_common.js
@@ -19,11 +19,19 @@ var async = require("async");
 exports.init = function(callback)
 {
   var testTableExists = "SELECT 1 as exists FROM pg_tables WHERE tablename = 'store'";
+  var testValueColumnType = "SELECT data_type FROM information_schema.columns " +
+    "WHERE table_name = 'store' " +
+    "AND column_name = 'value'";
 
   var createTable = 'CREATE TABLE store (' +
     '"key" character varying(100) NOT NULL, ' +
-    '"value" text NOT NULL, ' +
+    '"value" jsonb NOT NULL, ' +
     'CONSTRAINT store_pkey PRIMARY KEY (key))';
+
+  var updateValueColumnType = "ALTER TABLE store " +
+    "ALTER COLUMN value " +
+    "TYPE jsonb " +
+    "USING value::jsonb";
 
   var _this = this;
 
@@ -80,6 +88,16 @@ exports.init = function(callback)
     if (result.rows.length == 0) {
       _this.db.query(createTable, detectUpsertMethod(callback));
     } else {
+      _this.db.query(testValueColumnType, function(err, result) {
+	/* we already checked whether the table exists, so we can reasonably assume
+	 * the column does as well
+	 */
+	if (result.rows[0].data_type != "jsonb") {
+	  _this.db.query(updateValueColumnType, function(err, result) {
+	    if (err) {
+	      callback(err, null);
+	    }});
+	}});
       detectUpsertMethod(callback);
     }
   });

--- a/databases/postgres_db.js
+++ b/databases/postgres_db.js
@@ -23,7 +23,7 @@ exports.database = function(settings)
 
   this.settings.cache = settings.cache || 1000;
   this.settings.writeInterval = 100;
-  this.settings.json = true;
+  this.settings.json = false;
 
   this.db = new pg.Client(this.settings);
   this.db.connect();

--- a/databases/postgrespool_db.js
+++ b/databases/postgrespool_db.js
@@ -23,7 +23,7 @@ exports.database = function(settings)
 
   this.settings.cache = settings.cache || 1000;
   this.settings.writeInterval = 100;
-  this.settings.json = true;
+  this.settings.json = false;
 
   // Pool specific defaults
   this.settings.max = this.settings.max || 20;


### PR DESCRIPTION
This is supported since Postgres 9.2.  At the moment, Debian oldstable (jessie)
ships 9.6, and CentOS 6 – which is supported until November this year –
8.something.  I doubt anyone will really run anything older than this, and not
supporting CentOS 6 seems okay to me.

The init function will automatically check the data type of the value column and
migrate if it’s still text.

I hope the code is sensible, this is my first time writing JavaScript …