### PR TITLE
Remove sqlite3 from dependencies

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           node-version: 12
       - run: npm ci
+      # Optional dependencies must be installed manually.
+      - run: npm i sqlite3
 
       # Verify databases are reachable.
       - name: MySQL client and server check

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "rethinkdb": "^2.4.2",
     "rimraf": "^3.0.2",
     "simple-git": "^2.4.0",
-    "sqlite3": "^5.0.0",
     "wtfnode": "^0.8.4"
   },
   "optionalDependencies": {


### PR DESCRIPTION
It is already an optional dependency, and should stay that way due to the need to compile C code (on some platforms).