### PR TITLE
WORK IN PROGRESS -- PLEASE IGNORE ME -- Asyncify mysql_db.js and CacheAndBufferLayer.js, and other cleanups

### DIFF
--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const async = require('async');
+const util = require('util');
 
 exports.Database = function (settings) {
   // temp hack needs a proper fix..
@@ -50,6 +50,15 @@ exports.Database = function (settings) {
   this.settings.json = true;
 };
 
+exports.Database.prototype._query = async function (...args) {
+  return await new Promise((resolve, reject) => {
+    this.db.query(...args, (err, ...args) => {
+      if (err != null) return reject(err);
+      resolve(args);
+    });
+  });
+};
+
 exports.Database.prototype.clearPing = function () {
   if (this.interval) {
     clearInterval(this.interval);
@@ -68,6 +77,10 @@ exports.Database.prototype.schedulePing = function () {
 };
 
 exports.Database.prototype.init = function (callback) {
+  return util.callbackify(this._init.bind(this))(callback);
+};
+
+exports.Database.prototype._init = async function () {
   const db = this.db;
 
   const sqlCreate = `${'CREATE TABLE IF NOT EXISTS `store` ( ' +
@@ -78,105 +91,87 @@ exports.Database.prototype.init = function (callback) {
 
   const sqlAlter = 'ALTER TABLE store MODIFY `key` VARCHAR(100) COLLATE utf8mb4_bin;';
 
-  db.query({
+  await this._query({
     sql: sqlCreate,
     timeout: 60000,
-  }, [], (err) => {
-    // call the main callback
-    callback(err);
+  }, []);
 
-    // Checks for Database charset et al
-    const dbCharSet =
-        'SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME ' +
-        `FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '${db.database}'`;
-    db.query({
-      sql: dbCharSet,
-      timeout: 60000,
-    }, (err, result) => {
-      result = JSON.parse(JSON.stringify(result));
-      if (result[0].DEFAULT_CHARACTER_SET_NAME !== db.charset) {
-        console.error(`Database is not configured with charset ${db.charset} -- ` +
-                      'This may lead to crashes when certain characters are pasted in pads');
-        console.log(result[0], db.charset);
-      }
-
-      if (result[0].DEFAULT_COLLATION_NAME.indexOf(db.charset) === -1) {
-        console.error(
-            `Database is not configured with collation name that includes ${db.charset} -- ` +
-            'This may lead to crashes when certain characters are pasted in pads');
-        console.log(result[0], db.charset, result[0].DEFAULT_COLLATION_NAME);
-      }
-    });
-
-    const tableCharSet =
-        'SELECT CCSA.character_set_name AS character_set_name ' +
-        'FROM information_schema.`TABLES` ' +
-        'T,information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA ' +
-        'WHERE CCSA.collation_name = T.table_collation ' +
-        `AND T.table_schema = '${db.database}' ` +
-        "AND T.table_name = 'store'";
-    db.query({
-      sql: tableCharSet,
-      timeout: 60000,
-    }, (err, result, tf) => {
-      if (!result[0]) {
-        console.warn('Data has no character_set_name value -- ' +
-                     'This may lead to crashes when certain characters are pasted in pads');
-      }
-      if (result[0] && (result[0].character_set_name !== db.charset)) {
-        console.error(`table is not configured with charset ${db.charset} -- ` +
-                      'This may lead to crashes when certain characters are pasted in pads');
-        console.log(result[0], db.charset);
-      }
-    });
-
-    // check migration level, alter if not migrated
-    this.get('MYSQL_MIGRATION_LEVEL', (err, level) => {
-      if (err) {
-        throw err;
-      }
-
-      if (level !== '1') {
-        db.query({
-          sql: sqlAlter,
-          timeout: 60000,
-        }, [], (err) => {
-          if (err) {
-            throw err;
-          }
-
-          this.set('MYSQL_MIGRATION_LEVEL', '1', (err) => {
-            if (err) {
-              throw err;
-            }
-          });
-        });
-      }
-    });
+  // Checks for Database charset et al
+  const dbCharSet =
+      'SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME ' +
+      `FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '${db.database}'`;
+  let [result] = await this._query({
+    sql: dbCharSet,
+    timeout: 60000,
   });
+
+  result = JSON.parse(JSON.stringify(result));
+  if (result[0].DEFAULT_CHARACTER_SET_NAME !== db.charset) {
+    console.error(`Database is not configured with charset ${db.charset} -- ` +
+                  'This may lead to crashes when certain characters are pasted in pads');
+    console.log(result[0], db.charset);
+  }
+
+  if (result[0].DEFAULT_COLLATION_NAME.indexOf(db.charset) === -1) {
+    console.error(
+        `Database is not configured with collation name that includes ${db.charset} -- ` +
+          'This may lead to crashes when certain characters are pasted in pads');
+    console.log(result[0], db.charset, result[0].DEFAULT_COLLATION_NAME);
+  }
+
+  const tableCharSet =
+      'SELECT CCSA.character_set_name AS character_set_name ' +
+      'FROM information_schema.`TABLES` ' +
+      'T,information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA ' +
+      'WHERE CCSA.collation_name = T.table_collation ' +
+      `AND T.table_schema = '${db.database}' ` +
+      "AND T.table_name = 'store'";
+  [result] = await this._query({
+    sql: tableCharSet,
+    timeout: 60000,
+  });
+  if (!result[0]) {
+    console.warn('Data has no character_set_name value -- ' +
+                 'This may lead to crashes when certain characters are pasted in pads');
+  }
+  if (result[0] && (result[0].character_set_name !== db.charset)) {
+    console.error(`table is not configured with charset ${db.charset} -- ` +
+                  'This may lead to crashes when certain characters are pasted in pads');
+    console.log(result[0], db.charset);
+  }
+
+  // check migration level, alter if not migrated
+  const level = await this._get('MYSQL_MIGRATION_LEVEL');
+
+  if (level !== '1') {
+    await this._query({
+      sql: sqlAlter,
+      timeout: 60000,
+    }, []);
+    await this._set('MYSQL_MIGRATION_LEVEL', '1');
+  }
 
   this.schedulePing();
 };
 
 exports.Database.prototype.get = function (key, callback) {
-  this.db.query({
+  return util.callbackify(this._get.bind(this))(key, callback);
+};
+
+exports.Database.prototype._get = async function (key) {
+  const [results] = await this._query({
     sql: 'SELECT `value` FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
     timeout: 60000,
-  }, [key, key],
-  (err, results) => {
-    let value = null;
-
-    if (!err && results.length === 1) {
-      value = results[0].value;
-    }
-
-    callback(err, value);
-  });
-
+  }, [key, key]);
   this.schedulePing();
+  return results.length === 1 ? results[0].value : null;
 };
 
 exports.Database.prototype.findKeys = function (key, notKey, callback) {
+  return util.callbackify(this._findKeys.bind(this))(key, notKey, callback);
+};
+
+exports.Database.prototype._findKeys = async function (key, notKey) {
   let query = 'SELECT `key` FROM `store` WHERE `key` LIKE ?';
   const params = [];
 
@@ -190,49 +185,44 @@ exports.Database.prototype.findKeys = function (key, notKey, callback) {
     query += ' AND `key` NOT LIKE ?';
     params.push(notKey);
   }
-  this.db.query(
-      {
-        sql: query,
-        timeout: 60000,
-      }, params, (err, results) => {
-        const value = [];
-
-        if (!err && results.length > 0) {
-          results.forEach((val) => {
-            value.push(val.key);
-          });
-        }
-
-        callback(err, value);
-      });
-
+  const [results] = await this._query({
+    sql: query,
+    timeout: 60000,
+  }, params);
   this.schedulePing();
+  return results.map((val) => val.key);
 };
 
 exports.Database.prototype.set = function (key, value, callback) {
-  if (key.length > 100) {
-    callback('Your Key can only be 100 chars');
-  } else {
-    this.db.query({
-      sql: 'REPLACE INTO `store` VALUES (?,?)',
-      timeout: 60000,
-    }, [key, value], (err, info) => {
-      callback(err);
-    });
-  }
+  return util.callbackify(this._set.bind(this))(key, value, callback);
+};
 
+exports.Database.prototype._set = async function (key, value) {
+  if (key.length > 100) throw new Error('Your Key can only be 100 chars');
+  await this._query({
+    sql: 'REPLACE INTO `store` VALUES (?,?)',
+    timeout: 60000,
+  }, [key, value]);
   this.schedulePing();
 };
 
 exports.Database.prototype.remove = function (key, callback) {
-  this.db.query({
+  return util.callbackify(this._remove.bind(this))(key, callback);
+};
+
+exports.Database.prototype._remove = async function (key) {
+  await this._query({
     sql: 'DELETE FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
     timeout: 60000,
-  }, [key, key], callback);
+  }, [key, key]);
   this.schedulePing();
 };
 
 exports.Database.prototype.doBulk = function (bulk, callback) {
+  return util.callbackify(this._doBulk.bind(this))(bulk, callback);
+};
+
+exports.Database.prototype._doBulk = async function (bulk) {
   let replaceSQL = 'REPLACE INTO `store` VALUES ';
 
   // keysToDelete is a string of the form "(k1, k2, ..., kn)" painstakingly built by hand.
@@ -241,17 +231,17 @@ exports.Database.prototype.doBulk = function (bulk, callback) {
   let firstReplace = true;
   let firstRemove = true;
 
-  for (const i in bulk) {
-    if (bulk[i].type === 'set') {
+  for (const op of bulk) {
+    if (op.type === 'set') {
       if (!firstReplace) replaceSQL += ',';
       firstReplace = false;
 
-      replaceSQL += `(${this.db.escape(bulk[i].key)}, ${this.db.escape(bulk[i].value)})`;
-    } else if (bulk[i].type === 'remove') {
+      replaceSQL += `(${this.db.escape(op.key)}, ${this.db.escape(op.value)})`;
+    } else if (op.type === 'remove') {
       if (!firstRemove) keysToDelete += ',';
       firstRemove = false;
 
-      keysToDelete += this.db.escape(bulk[i].key);
+      keysToDelete += this.db.escape(op.key);
     }
   }
 
@@ -263,30 +253,10 @@ exports.Database.prototype.doBulk = function (bulk, callback) {
       `DELETE FROM \`store\` WHERE \`key\` IN ${keysToDelete} ` +
       `AND BINARY \`key\` IN ${keysToDelete};`;
 
-  async.parallel([
-    (callback) => {
-      if (!firstReplace) {
-        this.db.query({
-          sql: replaceSQL,
-          timeout: 60000,
-        },
-        callback);
-      } else {
-        callback();
-      }
-    },
-    (callback) => {
-      if (!firstRemove) {
-        this.db.query({
-          sql: removeSQL,
-          timeout: 60000,
-        },
-        callback);
-      } else {
-        callback();
-      }
-    },
-  ], callback);
+  await Promise.all([
+    firstReplace ? null : this._query({sql: replaceSQL, timeout: 60000}),
+    firstRemove ? null : this._query({sql: removeSQL, timeout: 60000}),
+  ]);
 
   this.schedulePing();
 };

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -33,7 +33,7 @@
  * overwriden by the driver and by the module user.
  */
 
-const async = require('async');
+const util = require('util');
 
 const defaultSettings =
 {
@@ -114,113 +114,152 @@ exports.Database = function (wrappedDB, settings, logger) {
 };
 
 /**
- wraps the init function of the original DB
-*/
-exports.Database.prototype.init = function (callback) {
-  this.wrappedDB.init(callback);
+ * wraps the init function of the original DB
+ * @param callback Node-style callback. If null, a Promise is returned instead.
+ */
+exports.Database.prototype.init = function (callback = null) {
+  const init = this.wrappedDB.init.bind(this.wrappedDB);
+  if (callback == null) return util.promisify(init)();
+  init(callback);
 };
 
 /**
- wraps the close function of the original DB
-*/
-exports.Database.prototype.close = function (callback) {
-  this.wrappedDB.close(callback);
+ * wraps the close function of the original DB
+ * @param callback Node-style callback. If null, a Promise is returned instead.
+ */
+exports.Database.prototype.close = function (callback = null) {
+  const close = this.wrappedDB.close.bind(this.wrappedDB);
+  if (callback == null) return util.promisify(close)();
+  close(callback);
 };
 
 /**
- Calls the callback the next time all buffers are flushed
-*/
-exports.Database.prototype.doShutdown = function (callback) {
+ * Calls the callback the next time all buffers are flushed
+ * @param callback Node-style callback. If null, a Promise is returned instead.
+ */
+exports.Database.prototype.doShutdown = function (callback = null) {
+  let p;
+  if (callback == null) {
+    p = new Promise((resolve, reject) => {
+      callback = (err) => { if (err != null) return reject(err); resolve(); };
+    });
+  }
   // wait until the buffer is fully written
   if (this.settings.writeInterval > 0) this.shutdownCallback = callback;
   // we write direct, so there is no need to wait for a callback
   else callback();
+  return p;
 };
 
 /**
- Gets the value trough the wrapper.
-*/
-exports.Database.prototype.get = function (key, callback) {
+ * Gets the value trough the wrapper.
+ * @param callback Node-style callback. If null, a Promise is returned instead.
+ */
+exports.Database.prototype.get = function (key, callback = null) {
+  if (callback == null) return this._get(key);
+  util.callbackify(this._get.bind(this))(key, callback);
+};
+
+exports.Database.prototype._get = async function (key) {
   const entry = this.buffer[key];
   // if cache is enabled and data is in the cache, get the value from the cache
   if (this.settings.cache > 0 && entry) {
     this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from cache`);
     entry.timestamp = new Date().getTime();
-    callback(null, entry.value);
-  } else if (this.settings.cache === 0 && entry && entry.dirty) {
+    return entry.value;
+  }
+  if (this.settings.cache === 0 && entry && entry.dirty) {
     // caching is disabled but its still in a dirty writing cache, so we have to get the value out
     // of the cache too
     this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from dirty buffer`);
     entry.timestamp = new Date().getTime();
-    callback(null, entry.value);
-  } else {
-    // get it direct
-    this.wrappedDB.get(key, (err, value) => {
-      if (this.settings.json) {
-        try {
-          value = JSON.parse(value);
-        } catch (e) {
-          console.error(`JSON-PROBLEM:${value}`);
-          callback(e);
-          return;
-        }
-      }
-
-      // cache the value if caching is enabled
-      if (this.settings.cache > 0) {
-        this.buffer[key] = {
-          value,
-          dirty: false,
-          timestamp: new Date().getTime(),
-          writingInProgress: false,
-        };
-      }
-      this.bufferLength++;
-
-      // call the garbage collector
-      this.gc();
-
-      this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
-
-      callback(err, value);
-    });
+    return entry.value;
   }
+  // get it direct
+  let value = await util.promisify(this.wrappedDB.get.bind(this.wrappedDB))(key);
+  if (this.settings.json) {
+    try {
+      value = JSON.parse(value);
+    } catch (err) {
+      console.error(`JSON-PROBLEM:${value}`);
+      throw err;
+    }
+  }
+
+  // cache the value if caching is enabled
+  if (this.settings.cache > 0) {
+    this.buffer[key] = {
+      value,
+      dirty: false,
+      timestamp: new Date().getTime(),
+      writingInProgress: false,
+    };
+  }
+  this.bufferLength++;
+
+  // call the garbage collector
+  this.gc();
+
+  this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
+
+  return value;
 };
 
 /**
  * Find keys function searches the db sets for matching entries and
  * returns the key entries via callback.
+ * @param callback Node-style callback. If null, a Promise is returned instead.
  */
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback = null) {
+  if (callback == null) return this._findKeys(key, notKey);
+  util.callbackify(this._findKeys.bind(this))(key, notKey, callback);
+};
+
+exports.Database.prototype._findKeys = async function (key, notKey) {
   const bufferKey = `${key}-${notKey}`;
-  this.wrappedDB.findKeys(key, notKey, (err, keyValues) => {
-    // call the garbage collector
-    this.gc();
+  const keyValues = await util.promisify(this.wrappedDB.findKeys.bind(this.wrappedDB))(key, notKey);
 
-    this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
+  // call the garbage collector
+  this.gc();
 
-    callback(err, keyValues);
-  });
+  this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
+
+  return keyValues;
 };
 
 /**
  * Remove a record from the database
+ * @param bufferedCb Node-style callback that is called when the change has been buffered but not
+ *     yet written to disk.
+ * @param writtenCb Node-style callback that is called when the change has been written to disk. If
+ *     null, a Promise is returned instead.
  */
-exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
+exports.Database.prototype.remove = function (key, bufferedCb = () => {}, writtenCb = null) {
   this.logger.debug(`DELETE - ${key} - from database `);
 
-  this.set(key, null, bufferCallback, writeCallback);
+  return this.set(key, null, bufferedCb, writtenCb);
 };
 
 /**
- Sets the value trough the wrapper
-*/
-exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
-  // writing cache is enabled, so simply write it into the buffer
-  if (this.settings.writeInterval > 0) {
+ * Sets the value trough the wrapper
+ * @param bufferedCb Node-style callback that is called when the change has been buffered but not
+ *     yet written to disk.
+ * @param writtenCb Node-style callback that is called when the change has been written to disk. If
+ *     null, a Promise is returned instead.
+ */
+exports.Database.prototype.set = function (k, v, bufferedCb = () => {}, writtenCb = null) {
+  if (writtenCb == null) return this._set(k, v, bufferedCb);
+  util.callbackify(this._set.bind(this))(k, v, bufferedCb, writtenCb);
+};
+
+exports.Database.prototype._set = async function (key, value, bufferCallback = () => {}) {
+  const buffered = this.settings.writeInterval > 0;
+  let entry;
+  if (buffered) {
+    // writing cache is enabled, so simply write it into the buffer
     this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to buffer`);
 
-    let entry = this.buffer[key];
+    entry = this.buffer[key];
     // initalize the buffer object if it not exists
     if (!entry) {
       entry = this.buffer[key] = {};
@@ -234,111 +273,99 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
 
     // call the garbage collector
     this.gc();
-
-    // initalize the callback array in the buffer object if it not exists. we need this as an array,
-    // cause the value may be many times overwritten bevors its finally written to the database, but
-    // all callbacks must be called
-    if (!entry.callbacks) entry.callbacks = [];
-
-    // add this callback to the array
-    if (!writeCallback) writeCallback = (err) => { if (err != null) throw err; };
-    entry.callbacks.push(writeCallback);
-
-    // call the buffer callback
-    if (bufferCallback) bufferCallback();
   } else {
     // writecache is disabled, so we write directly to the database
     this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to database`);
 
-    // create a wrapper callback for write and buffer callback
-    const callback = (err) => {
-      if (bufferCallback) bufferCallback(err);
-      if (writeCallback) writeCallback(err);
-    };
-
-    // The value is null, means this no set operation, this is a remove operation
     if (value == null) {
-      this.wrappedDB.remove(key, callback);
+      // The value is null, means this no set operation, this is a remove operation
+      await util.promisify(this.wrappedDB.remove.bind(this.wrappedDB))(key);
     } else {
       // thats a correct value
       // stringify the value if stringifying is enabled
       if (this.settings.json === true) value = JSON.stringify(value);
-
-      this.wrappedDB.set(key, value, callback);
+      await util.promisify(this.wrappedDB.set.bind(this.wrappedDB))(key, value);
     }
+  }
+  bufferCallback();
+  if (buffered) {
+    // initalize the callback array in the buffer object if it not exists. we need this as an array,
+    // cause the value may be many times overwritten bevors its finally written to the database, but
+    // all callbacks must be called
+    if (!entry.callbacks) entry.callbacks = [];
+    await new Promise((resolve, reject) => {
+      entry.callbacks.push((err) => {
+        if (err != null) return reject(err);
+        resolve();
+      });
+    });
   }
 };
 
 /**
- Sets a subvalue
-*/
-exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
+ * Sets a subvalue
+ * @param bufferedCb Node-style callback that is called when the change has been buffered but not
+ *     yet written to disk.
+ * @param writtenCb Node-style callback that is called when the change has been written to disk. If
+ *     null, a Promise is returned instead.
+ */
+exports.Database.prototype.setSub = function (k, sub, v, bufferedCb = () => {}, writtenCb = null) {
+  if (writtenCb == null) return this._setSub(k, sub, v, bufferedCb);
+  util.callbackify(this._setSub.bind(this))(k, sub, v, bufferedCb, writtenCb);
+};
+
+exports.Database.prototype._setSub = async function (key, sub, value, bufferCallback = () => {}) {
   this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
-
-  async.waterfall([
-    // get the full value
-    (callback) => {
-      this.get(key, callback);
-    },
-    // set the sub value and set the full value again
-    (fullValue, callback) => {
-      // get the subvalue parent
-      let subvalueParent = fullValue;
-      for (let i = 0; i < (sub.length - 1); i++) {
-        // test if the subvalue exist
-        if (subvalueParent != null && subvalueParent[sub[i]] !== undefined) {
-          subvalueParent = subvalueParent[sub[i]];
-        } else {
-          // the subvalue doesn't exist, create it
-          subvalueParent[sub[i]] = {};
-          subvalueParent = subvalueParent[sub[i]];
-        }
+  let fullValue;
+  try {
+    fullValue = await this._get(key);
+    // get the subvalue parent
+    let subvalueParent = fullValue;
+    for (let i = 0; i < (sub.length - 1); i++) {
+      // test if the subvalue exist
+      if (subvalueParent != null && subvalueParent[sub[i]] !== undefined) {
+        subvalueParent = subvalueParent[sub[i]];
+      } else {
+        // the subvalue doesn't exist, create it
+        subvalueParent[sub[i]] = {};
+        subvalueParent = subvalueParent[sub[i]];
       }
-
-      // set the subvalue, we're doing that with the parent element
-      subvalueParent[sub[sub.length - 1]] = value;
-      this.set(key, fullValue, bufferCallback, writeCallback);
-      callback(null);
-    },
-  ], (err) => {
-    if (err) {
-      if (bufferCallback) bufferCallback(err);
-      else if (writeCallback) writeCallback(err);
-      else throw err;
     }
-  });
+    // set the subvalue, we're doing that with the parent element
+    subvalueParent[sub[sub.length - 1]] = value;
+  } catch (err) {
+    bufferCallback(err);
+    throw err;
+  }
+  return await this._set(key, fullValue, bufferCallback);
 };
 
 /**
  * Returns a sub value of the object
  * @param sub is a array, for example if you want to access object.test.bla, the array is ["test",
  *     "bla"]
+ * @param callback Node-style callback. If null, a Promise is returned instead.
  */
-exports.Database.prototype.getSub = function (key, sub, callback) {
-  // get the full value
-  this.get(key, (err, value) => {
-    // there happens an errror while getting this value, call callback
-    if (err) {
-      callback(err);
+exports.Database.prototype.getSub = function (key, sub, callback = null) {
+  if (callback == null) return this._getSub(key, sub);
+  util.callbackify(this._getSub.bind(this))(key, sub, callback);
+};
+
+exports.Database.prototype._getSub = async function (key, sub) {
+  const value = await this._get(key);
+  let subvalue = value;
+  for (let i = 0; i < sub.length; i++) {
+    // test if the subvalue exist
+    if (subvalue != null && subvalue[sub[i]] !== undefined) {
+      subvalue = subvalue[sub[i]];
     } else {
-      // everything is correct, navigate to the subvalue and return it
-      let subvalue = value;
-
-      for (let i = 0; i < sub.length; i++) {
-        // test if the subvalue exist
-        if (subvalue != null && subvalue[sub[i]] !== undefined) {
-          subvalue = subvalue[sub[i]];
-        } else {
-          // the subvalue doesn't exist, break the loop and return null
-          subvalue = null;
-          break;
-        }
-      }
-
-      this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
-      callback(err, subvalue);
+      // the subvalue doesn't exist, break the loop and return null
+      subvalue = null;
+      break;
     }
-  });
+  }
+  this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+  return subvalue;
 };
 
 /**
@@ -375,12 +402,8 @@ exports.Database.prototype.gc = function () {
 /**
  Writes all dirty values to the database
 */
-const flush = (db, callback) => {
-  // return if there is a flushing action in process
-  if (db.isFlushing) {
-    if (callback) callback();
-    return;
-  }
+const flush = async (db) => {
+  if (db.isFlushing) return;
 
   const operations = [];
   let callbacks = [];
@@ -421,25 +444,27 @@ const flush = (db, callback) => {
     // set the flushing flag
     db.isFlushing = true;
 
-    db.wrappedDB.doBulk(operations, (err) => {
-      // call all writingCallbacks
-      for (const cb of callbacks) {
-        cb(err);
-      }
+    let err = null;
+    try {
+      await util.promisify(db.wrappedDB.doBulk.bind(db.wrappedDB))(operations);
+    } catch (error) {
+      err = error || new Error(error);
+    }
+    // call all writingCallbacks
+    for (const cb of callbacks) {
+      cb(err);
+    }
 
-      // set the writingInProgress flag to false
-      for (const {key} of operations) {
-        db.buffer[key].writingInProgress = false;
-      }
+    // set the writingInProgress flag to false
+    for (const {key} of operations) {
+      db.buffer[key].writingInProgress = false;
+    }
 
-      if (callback) callback();
+    // call the garbage collector
+    db.gc();
 
-      // call the garbage collector
-      db.gc();
-
-      // set the flushing flag to false
-      db.isFlushing = false;
-    });
+    // set the flushing flag to false
+    db.isFlushing = false;
   } else if (db.shutdownCallback != null) {
     // the writing buffer is empty and there is a shutdown callback, call it!
     clearInterval(db.flushInterval);


### PR DESCRIPTION
Multiple commits:
* Use `this` instead of `self`, `_this`, or `that`
* Simplify write callback conditional
* Avoid iterating over inherited properties
* Avoid repeated key lookups
* Invert the dirty check to reduce indent level (for readability)
* Asyncify `CacheAndBufferLayer.js`
* Asyncify `mysql_db.js`

Before this change many errors were silently ignored. Now they are propagated up, partially addressing #153.