### PR TITLE
Various cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install ueberdb2
 const ueberdb = require('ueberdb2');
 
 // mysql
-const db = new ueberdb.database('mysql', {
+const db = new ueberdb.Database('mysql', {
   user: 'root',
   host: 'localhost',
   password: '',
@@ -48,7 +48,7 @@ const db = new ueberdb.database('mysql', {
 });
 
 // dirty to file system
-//const db = new ueberdb.database('dirty', {filename: 'var/dirty.db'});
+//const db = new ueberdb.Database('dirty', {filename: 'var/dirty.db'});
 
 async function example(db) {
   await db.init();
@@ -71,7 +71,7 @@ example(db);
 
 ```javascript
 const ueberdb = require('ueberdb2');
-const db = new ueberdb.database('dirty', {filename: 'var/dirty.db'});
+const db = new ueberdb.Database('dirty', {filename: 'var/dirty.db'});
 
 async function example(db){
   await db.init();
@@ -138,7 +138,7 @@ Set `db.cache = 0;` to disable caching of reads and writes.
 
 ```javascript
 const ueberdb = require('ueberdb2');
-const db = new ueberdb.database('dirty', {filename: 'var/dirty.db'});
+const db = new ueberdb.Database('dirty', {filename: 'var/dirty.db'});
 
 // going cacheless
 async function example(db){

--- a/databases/cassandra_db.js
+++ b/databases/cassandra_db.js
@@ -29,7 +29,7 @@ const util = require('util');
  *     the Cassandra driver. See https://github.com/datastax/nodejs-driver#logging for more
  *     information
  */
-exports.database = function (settings) {
+exports.Database = function (settings) {
   if (!settings.clientOptions) {
     throw new Error('The Cassandra client options should be defined');
   }
@@ -50,7 +50,7 @@ exports.database = function (settings) {
  * @param  {Function}   callback        Standard callback method.
  * @param  {Error}      callback.err    An error object (if any.)
  */
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   // Create a client
   this.client = new cassandra.Client(this.settings.clientOptions);
 
@@ -97,7 +97,7 @@ exports.database.prototype.init = function (callback) {
  * @param  {Error}      callback.err      An error object, if any
  * @param  {String}     callback.value    The value for the given key (if any)
  */
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   const cql = util.format('SELECT data FROM "%s" WHERE key = ?', this.settings.columnFamily);
   this.client.execute(cql, [key], (err, result) => {
     if (err) {
@@ -123,7 +123,7 @@ exports.database.prototype.get = function (key, callback) {
  * @param  {Error}      callback.err      An error object, if any
  * @param  {String[]}   callback.keys     An array of keys that match the specified filters
  */
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   let cql = null;
   if (!notKey) {
     // Get all the keys
@@ -181,7 +181,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
  * @param  {Function}   callback        Standard callback method
  * @param  {Error}      callback.err    An error object, if any
  */
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   this.doBulk([{type: 'set', key, value}], callback);
 };
 
@@ -192,7 +192,7 @@ exports.database.prototype.set = function (key, value, callback) {
  * @param  {Function}   callback        Standard callback method
  * @param  {Error}      callback.err    An error object, if any
  */
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.doBulk([{type: 'remove', key}], callback);
 };
 
@@ -203,7 +203,7 @@ exports.database.prototype.remove = function (key, callback) {
  * @param  {Function}   callback        Standard callback method
  * @param  {Error}      callback.err    An error object, if any
  */
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const queries = [];
   bulk.forEach((operation) => {
     // We support finding keys of the form `test:*`. If anything matches, we will try and save this
@@ -243,6 +243,6 @@ exports.database.prototype.doBulk = function (bulk, callback) {
  * @param  {Function}   callback        Standard callback method
  * @param  {Error}      callback.err    Error object in case something goes wrong
  */
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.pool.shutdown(callback);
 };

--- a/databases/cassandra_db.js
+++ b/databases/cassandra_db.js
@@ -14,7 +14,6 @@
  */
 
 const cassandra = require('cassandra-driver');
-const util = require('util');
 
 /**
  * Cassandra DB constructor.
@@ -80,9 +79,9 @@ exports.Database.prototype.init = function (callback) {
         if (isDefined) {
           return callback(null);
         } else {
-          const cql = util.format(
-              'CREATE COLUMNFAMILY "%s" (key text PRIMARY KEY, data text)',
-              this.settings.columnFamily);
+          const cql =
+              `CREATE COLUMNFAMILY "${this.settings.columnFamily}" ` +
+              '(key text PRIMARY KEY, data text)';
           this.client.execute(cql, callback);
         }
       });
@@ -98,7 +97,7 @@ exports.Database.prototype.init = function (callback) {
  * @param  {String}     callback.value    The value for the given key (if any)
  */
 exports.Database.prototype.get = function (key, callback) {
-  const cql = util.format('SELECT data FROM "%s" WHERE key = ?', this.settings.columnFamily);
+  const cql = `SELECT data FROM "${this.settings.columnFamily}" WHERE key = ?`;
   this.client.execute(cql, [key], (err, result) => {
     if (err) {
       return callback(err);
@@ -127,7 +126,7 @@ exports.Database.prototype.findKeys = function (key, notKey, callback) {
   let cql = null;
   if (!notKey) {
     // Get all the keys
-    cql = util.format('SELECT key FROM "%s"', this.settings.columnFamily);
+    cql = `SELECT key FROM "${this.settings.columnFamily}"`;
     this.client.execute(cql, (err, result) => {
       if (err) {
         return callback(err);
@@ -151,7 +150,7 @@ exports.Database.prototype.findKeys = function (key, notKey, callback) {
     if (matches) {
       // Get the 'text' bit out of the key and get all those keys from a special column.
       // We can retrieve them from this column as we're duplicating them on .set/.remove
-      cql = util.format('SELECT * from "%s" WHERE key = ?', this.settings.columnFamily);
+      cql = `SELECT * from "${this.settings.columnFamily}" WHERE key = ?`;
       this.client.execute(cql, [`ueberdb:keys:${matches[1]}`], (err, result) => {
         if (err) {
           return callback(err);
@@ -210,25 +209,25 @@ exports.Database.prototype.doBulk = function (bulk, callback) {
     const matches = /^([^:]+):([^:]+)$/.exec(operation.key);
     if (operation.type === 'set') {
       queries.push({
-        query: util.format('UPDATE "%s" SET data = ? WHERE key = ?', this.settings.columnFamily),
+        query: `UPDATE "${this.settings.columnFamily}" SET data = ? WHERE key = ?`,
         params: [operation.value, operation.key],
       });
 
       if (matches) {
         queries.push({
-          query: util.format('UPDATE "%s" SET data = ? WHERE key = ?', this.settings.columnFamily),
+          query: `UPDATE "${this.settings.columnFamily}" SET data = ? WHERE key = ?`,
           params: ['1', `ueberdb:keys:${matches[1]}`],
         });
       }
     } else if (operation.type === 'remove') {
       queries.push({
-        query: util.format('DELETE FROM "%s" WHERE key=?', this.settings.columnFamily),
+        query: `DELETE FROM "${this.settings.columnFamily}" WHERE key=?`,
         params: [operation.key],
       });
 
       if (matches) {
         queries.push({
-          query: util.format('DELETE FROM "%s" WHERE key = ?', this.settings.columnFamily),
+          query: `DELETE FROM "${this.settings.columnFamily}" WHERE key = ?`,
           params: [`ueberdb:keys:${matches[1]}`],
         });
       }

--- a/databases/couch_db.js
+++ b/databases/couch_db.js
@@ -25,7 +25,7 @@ const handleError = (er) => {
   if (er) throw new Error(er);
 };
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.db = null;
   this.client = null;
   this.settings = settings;
@@ -37,7 +37,7 @@ exports.database = function (settings) {
   this.settings.json = false;
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   const settings = this.settings;
   let client = null;
   let db = null;
@@ -87,7 +87,7 @@ exports.database.prototype.init = function (callback) {
   });
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   const db = this.db;
   db.get(key, (er, doc) => {
     if (er && er.statusCode !== 404) {
@@ -99,7 +99,7 @@ exports.database.prototype.get = function (key, callback) {
   });
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const regex = this.createFindRegex(key, notKey);
   const queryKey = `${key}__${notKey}`;
   const db = this.db;
@@ -138,7 +138,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   checkQuery();
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   const db = this.db;
   db.get(key, (er, doc) => {
     if (doc == null) return db.insert({_id: key, value}, callback);
@@ -146,7 +146,7 @@ exports.database.prototype.set = function (key, value, callback) {
   });
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   const db = this.db;
   db.head(key, (er, _, header) => {
     if (er && er.statusCode === 404) return callback(null);
@@ -160,7 +160,7 @@ exports.database.prototype.remove = function (key, callback) {
   });
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const db = this.db;
   const keys = bulk.map((op) => op.key);
   const revs = {};
@@ -193,6 +193,6 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   );
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   if (callback) callback();
 };

--- a/databases/dirty_db.js
+++ b/databases/dirty_db.js
@@ -24,7 +24,7 @@
 
 const Dirty = require('dirty');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.db = null;
 
   if (!settings || !settings.filename) {
@@ -39,18 +39,18 @@ exports.database = function (settings) {
   this.settings.json = false;
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   this.db = new Dirty(this.settings.filename);
   this.db.on('load', (err) => {
     callback();
   });
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   callback(null, this.db.get(key));
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const keys = [];
   const regex = this.createFindRegex(key, notKey);
   this.db.forEach((key, val) => {
@@ -61,15 +61,15 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   callback(null, keys);
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   this.db.set(key, value, callback);
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.db.rm(key, callback);
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.db.close();
   if (callback) callback();
 };

--- a/databases/dirty_git_db.js
+++ b/databases/dirty_git_db.js
@@ -17,7 +17,7 @@
 
 const Dirty = require('dirty');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.db = null;
 
   if (!settings || !settings.filename) {
@@ -32,18 +32,18 @@ exports.database = function (settings) {
   this.settings.json = false;
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   this.db = new Dirty(this.settings.filename);
   this.db.on('load', (err) => {
     callback();
   });
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   callback(null, this.db.get(key));
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const keys = [];
   const regex = this.createFindRegex(key, notKey);
   this.db.forEach((key, val) => {
@@ -54,7 +54,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   callback(null, keys);
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   this.db.set(key, value, callback);
   const databasePath = require('path').dirname(this.settings.filename);
   require('simple-git')(databasePath)
@@ -64,11 +64,11 @@ exports.database.prototype.set = function (key, value, callback) {
       .push(['-u', 'origin', 'master'], () => console.debug('Stored git commit'));
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.db.rm(key, callback);
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.db.close();
   if (callback) callback();
 };

--- a/databases/elasticsearch_db.js
+++ b/databases/elasticsearch_db.js
@@ -30,7 +30,7 @@ const elasticsearchSettings = {
 
 let client;
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.db = null;
 
   this.settings = settings || {};
@@ -57,7 +57,7 @@ exports.database = function (settings) {
  * Initialize the elasticsearch client, then ping the server to ensure that a
  * connection was made.
  */
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   // create elasticsearch client
   client = new es.Client({
     host: `${elasticsearchSettings.hostname}:${elasticsearchSettings.port}`,
@@ -85,7 +85,7 @@ exports.database.prototype.init = function (callback) {
  *  @param {function} callback Function will be called in the event of an error or
  *    upon completion of a successful database retrieval.
  */
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   client.get(getIndexTypeId(key), (error, response) => {
     parseResponse(error, response, callback);
   });
@@ -106,7 +106,7 @@ exports.database.prototype.get = function (key, callback) {
  *  @param notKey Used to filter the result set
  *  @param callback First param is error, second is result
  */
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const splitKey = key.split(':');
 
   client.search({
@@ -141,7 +141,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
  *  @param {function} callback Function will be called in the event of an error or on
  *    completion of a successful database write.
  */
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   const options = getIndexTypeId(key);
 
   options.body = {
@@ -164,7 +164,7 @@ exports.database.prototype.set = function (key, value, callback) {
  *  @param {function} callback Function will be called in the event of an error or on
  *    completion of a successful database write.
  */
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   client.delete(key, (error, response) => {
     parseResponse(error, response, callback);
   });
@@ -181,7 +181,7 @@ exports.database.prototype.remove = function (key, callback) {
  *  @param {function} callback This function will be called on an error or upon the
  *      successful completion of the database write.
  */
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   // bulk is an array of JSON:
   // example: [{"type":"set", "key":"sessionstorage:{id}", "value":{"cookie":{...}}]
 
@@ -216,7 +216,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   });
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   callback(null);
 };
 

--- a/databases/mongodb_db.js
+++ b/databases/mongodb_db.js
@@ -32,10 +32,8 @@ exports.database.prototype.clearPing = function () {
 
 exports.database.prototype.schedulePing = function () {
   this.clearPing();
-
-  const self = this;
   this.interval = setInterval(() => {
-    self.database.command({
+    this.database.command({
       ping: 1,
     });
   }, 10000);

--- a/databases/mongodb_db.js
+++ b/databases/mongodb_db.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.settings = settings;
 
   if (!this.settings.url) throw new Error('You must specify a mongodb url');
@@ -24,13 +24,13 @@ exports.database = function (settings) {
   if (!this.settings.collection) this.settings.collection = 'ueberdb';
 };
 
-exports.database.prototype.clearPing = function () {
+exports.Database.prototype.clearPing = function () {
   if (this.interval) {
     clearInterval(this.interval);
   }
 };
 
-exports.database.prototype.schedulePing = function () {
+exports.Database.prototype.schedulePing = function () {
   this.clearPing();
   this.interval = setInterval(() => {
     this.database.command({
@@ -39,7 +39,7 @@ exports.database.prototype.schedulePing = function () {
   }, 10000);
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   const MongoClient = require('mongodb').MongoClient;
 
   MongoClient.connect(this.settings.url, (err, client) => {
@@ -55,7 +55,7 @@ exports.database.prototype.init = function (callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   this.collection.findOne({_id: key}, (err, document) => {
     if (err) callback(err);
     else callback(null, document ? document.value : null);
@@ -64,7 +64,7 @@ exports.database.prototype.get = function (key, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const selector = {
     $and: [
       {_id: {$regex: `${key.replace(/\*/g, '')}`}},
@@ -88,7 +88,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   if (key.length > 100) {
     callback('Your Key can only be 100 chars');
   } else {
@@ -98,13 +98,13 @@ exports.database.prototype.set = function (key, value, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.collection.remove({_id: key}, callback);
 
   this.schedulePing();
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const bulkMongo = this.collection.initializeOrderedBulkOp();
 
   for (const i in bulk) {
@@ -124,7 +124,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.clearPing();
   this.client.close(callback);
 };

--- a/databases/mssql_db.js
+++ b/databases/mssql_db.js
@@ -24,7 +24,7 @@
 const async = require('async');
 const mssql = require('mssql');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   settings = settings || {};
 
   if (settings.json != null) {
@@ -46,7 +46,7 @@ exports.database = function (settings) {
   this.settings.writeInterval = 0;
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   const sqlCreate =
     "IF OBJECT_ID(N'dbo.store', N'U') IS NULL" +
     '  BEGIN' +
@@ -71,7 +71,7 @@ exports.database.prototype.init = function (callback) {
   });
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   const request = new mssql.Request(this.db);
 
   request.input('key', mssql.NVarChar(100), key);
@@ -87,7 +87,7 @@ exports.database.prototype.get = function (key, callback) {
   });
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const request = new mssql.Request(this.db);
   let query = 'SELECT [key] FROM [store] WHERE [key] LIKE @key';
 
@@ -116,7 +116,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   });
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   const request = new mssql.Request(this.db);
 
   if (key.length > 100) {
@@ -137,13 +137,13 @@ exports.database.prototype.set = function (key, value, callback) {
   }
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   const request = new mssql.Request(this.db);
   request.input('key', mssql.NVarChar(100), key);
   request.query('DELETE FROM [store] WHERE [key] = @key', callback);
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const maxInserts = 100;
   const request = new mssql.Request(this.db);
   let firstReplace = true;
@@ -209,6 +209,6 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   );
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.db.close(callback);
 };

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -59,9 +59,8 @@ exports.database.prototype.clearPing = function () {
 exports.database.prototype.schedulePing = function () {
   this.clearPing();
 
-  const self = this;
   this.interval = setInterval(() => {
-    self.db.query({
+    this.db.query({
       sql: 'SELECT 1',
       timeout: 60000,
     });
@@ -70,7 +69,6 @@ exports.database.prototype.schedulePing = function () {
 
 exports.database.prototype.init = function (callback) {
   const db = this.db;
-  const self = this;
 
   const sqlCreate = `${'CREATE TABLE IF NOT EXISTS `store` ( ' +
                   '`key` VARCHAR( 100 ) NOT NULL COLLATE utf8mb4_bin, ' +
@@ -133,7 +131,7 @@ exports.database.prototype.init = function (callback) {
     });
 
     // check migration level, alter if not migrated
-    self.get('MYSQL_MIGRATION_LEVEL', (err, level) => {
+    this.get('MYSQL_MIGRATION_LEVEL', (err, level) => {
       if (err) {
         throw err;
       }
@@ -147,7 +145,7 @@ exports.database.prototype.init = function (callback) {
             throw err;
           }
 
-          self.set('MYSQL_MIGRATION_LEVEL', '1', (err) => {
+          this.set('MYSQL_MIGRATION_LEVEL', '1', (err) => {
             if (err) {
               throw err;
             }
@@ -235,8 +233,6 @@ exports.database.prototype.remove = function (key, callback) {
 };
 
 exports.database.prototype.doBulk = function (bulk, callback) {
-  const _this = this;
-
   let replaceSQL = 'REPLACE INTO `store` VALUES ';
 
   // keysToDelete is a string of the form "(k1, k2, ..., kn)" painstakingly built by hand.
@@ -250,12 +246,12 @@ exports.database.prototype.doBulk = function (bulk, callback) {
       if (!firstReplace) replaceSQL += ',';
       firstReplace = false;
 
-      replaceSQL += `(${_this.db.escape(bulk[i].key)}, ${_this.db.escape(bulk[i].value)})`;
+      replaceSQL += `(${this.db.escape(bulk[i].key)}, ${this.db.escape(bulk[i].value)})`;
     } else if (bulk[i].type === 'remove') {
       if (!firstRemove) keysToDelete += ',';
       firstRemove = false;
 
-      keysToDelete += _this.db.escape(bulk[i].key);
+      keysToDelete += this.db.escape(bulk[i].key);
     }
   }
 
@@ -270,7 +266,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   async.parallel([
     (callback) => {
       if (!firstReplace) {
-        _this.db.query({
+        this.db.query({
           sql: replaceSQL,
           timeout: 60000,
         },
@@ -281,7 +277,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
     },
     (callback) => {
       if (!firstRemove) {
-        _this.db.query({
+        this.db.query({
           sql: removeSQL,
           timeout: 60000,
         },

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -17,7 +17,7 @@
 
 const async = require('async');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   // temp hack needs a proper fix..
   if (settings && !settings.charset) settings.charset = 'utf8mb4';
 
@@ -50,13 +50,13 @@ exports.database = function (settings) {
   this.settings.json = true;
 };
 
-exports.database.prototype.clearPing = function () {
+exports.Database.prototype.clearPing = function () {
   if (this.interval) {
     clearInterval(this.interval);
   }
 };
 
-exports.database.prototype.schedulePing = function () {
+exports.Database.prototype.schedulePing = function () {
   this.clearPing();
 
   this.interval = setInterval(() => {
@@ -67,7 +67,7 @@ exports.database.prototype.schedulePing = function () {
   }, 10000);
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   const db = this.db;
 
   const sqlCreate = `${'CREATE TABLE IF NOT EXISTS `store` ( ' +
@@ -158,7 +158,7 @@ exports.database.prototype.init = function (callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   this.db.query({
     sql: 'SELECT `value` FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
     timeout: 60000,
@@ -176,7 +176,7 @@ exports.database.prototype.get = function (key, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   let query = 'SELECT `key` FROM `store` WHERE `key` LIKE ?';
   const params = [];
 
@@ -209,7 +209,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   if (key.length > 100) {
     callback('Your Key can only be 100 chars');
   } else {
@@ -224,7 +224,7 @@ exports.database.prototype.set = function (key, value, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.db.query({
     sql: 'DELETE FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
     timeout: 60000,
@@ -232,7 +232,7 @@ exports.database.prototype.remove = function (key, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   let replaceSQL = 'REPLACE INTO `store` VALUES ';
 
   // keysToDelete is a string of the form "(k1, k2, ..., kn)" painstakingly built by hand.
@@ -291,7 +291,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   this.schedulePing();
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.clearPing();
   this.db.end(callback);
 };

--- a/databases/postgres_db.js
+++ b/databases/postgres_db.js
@@ -18,7 +18,7 @@
 const pg = require('pg');
 const postgresCommon = require('./postgres_common');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.settings = settings;
 
   this.settings.cache = settings.cache || 1000;
@@ -29,10 +29,10 @@ exports.database = function (settings) {
   this.db.connect();
 };
 
-exports.database.prototype.init = postgresCommon.init;
-exports.database.prototype.get = postgresCommon.get;
-exports.database.prototype.findKeys = postgresCommon.findKeys;
-exports.database.prototype.set = postgresCommon.set;
-exports.database.prototype.remove = postgresCommon.remove;
-exports.database.prototype.doBulk = postgresCommon.doBulk;
-exports.database.prototype.close = postgresCommon.close;
+exports.Database.prototype.init = postgresCommon.init;
+exports.Database.prototype.get = postgresCommon.get;
+exports.Database.prototype.findKeys = postgresCommon.findKeys;
+exports.Database.prototype.set = postgresCommon.set;
+exports.Database.prototype.remove = postgresCommon.remove;
+exports.Database.prototype.doBulk = postgresCommon.doBulk;
+exports.Database.prototype.close = postgresCommon.close;

--- a/databases/postgrespool_db.js
+++ b/databases/postgrespool_db.js
@@ -18,7 +18,7 @@
 const pg = require('pg');
 const postgresCommon = require('./postgres_common');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.settings = settings;
 
   this.settings.cache = settings.cache || 1000;
@@ -33,10 +33,10 @@ exports.database = function (settings) {
   this.db = new pg.Pool(this.settings);
 };
 
-exports.database.prototype.init = postgresCommon.init;
-exports.database.prototype.get = postgresCommon.get;
-exports.database.prototype.findKeys = postgresCommon.findKeys;
-exports.database.prototype.set = postgresCommon.set;
-exports.database.prototype.remove = postgresCommon.remove;
-exports.database.prototype.doBulk = postgresCommon.doBulk;
-exports.database.prototype.close = postgresCommon.close;
+exports.Database.prototype.init = postgresCommon.init;
+exports.Database.prototype.get = postgresCommon.get;
+exports.Database.prototype.findKeys = postgresCommon.findKeys;
+exports.Database.prototype.set = postgresCommon.set;
+exports.Database.prototype.remove = postgresCommon.remove;
+exports.Database.prototype.doBulk = postgresCommon.doBulk;
+exports.Database.prototype.close = postgresCommon.close;

--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -20,22 +20,22 @@
 const async = require('async');
 const redis = require('redis');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.client = null;
   this.settings = settings || {};
 };
 
-exports.database.prototype.auth = function (callback) {
+exports.Database.prototype.auth = function (callback) {
   if (this.settings.password) this.client.auth(this.settings.password, callback);
   callback();
 };
 
-exports.database.prototype.select = function (callback) {
+exports.Database.prototype.select = function (callback) {
   if (this.settings.database) return this.client.select(this.settings.database, callback);
   callback();
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   if (this.settings.socket) {
     this.client = redis.createClient(this.settings.socket,
         this.settings.client_options);
@@ -48,11 +48,11 @@ exports.database.prototype.init = function (callback) {
   async.waterfall([this.auth.bind(this), this.select.bind(this)], callback);
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   this.client.get(key, callback);
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   // As redis provides only limited support for getting a list of all
   // available keys we have to limit key and notKey here.
   // See http://redis.io/commands/keys
@@ -72,7 +72,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   }
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   const matches = /^([^:]+):([^:]+)$/.exec(key);
   if (matches) {
     this.client.sadd([`ueberDB:keys:${matches[1]}`, matches[0]]);
@@ -80,7 +80,7 @@ exports.database.prototype.set = function (key, value, callback) {
   this.client.set(key, value, callback);
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   const matches = /^([^:]+):([^:]+)$/.exec(key);
   if (matches) {
     this.client.srem([`ueberDB:keys:${matches[1]}`, matches[0]]);
@@ -88,7 +88,7 @@ exports.database.prototype.remove = function (key, callback) {
   this.client.del(key, callback);
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const multi = this.client.multi();
 
   for (const {key, type, value} of bulk) {
@@ -109,7 +109,7 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   multi.exec(callback);
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.client.quit(() => {
     callback();
   });

--- a/databases/rethink_db.js
+++ b/databases/rethink_db.js
@@ -33,23 +33,21 @@ exports.database = function (settings) {
 };
 
 exports.database.prototype.init = function (callback) {
-  const that = this;
-  r.connect(that, (err, conn) => {
+  r.connect(this, (err, conn) => {
     if (err) throw err;
-    that.connection = conn;
+    this.connection = conn;
 
-    r.table(that.table).run(that.connection, (err, cursor) => {
+    r.table(this.table).run(this.connection, (err, cursor) => {
       if (err) {
         // assuming table does not exists
-        r.tableCreate(that.table).run(that.connection, callback);
+        r.tableCreate(this.table).run(this.connection, callback);
       } else if (callback) { callback(null, cursor); }
     });
   });
 };
 
 exports.database.prototype.get = function (key, callback) {
-  const that = this;
-  r.table(that.table).get(key).run(that.connection, (err, item) => {
+  r.table(this.table).get(key).run(this.connection, (err, item) => {
     callback(err, (item ? item.content : item));
   });
 };
@@ -57,23 +55,20 @@ exports.database.prototype.get = function (key, callback) {
 exports.database.prototype.findKeys = function (key, notKey, callback) {
   const keys = [];
   const regex = this.createFindRegex(key, notKey);
-  const that = this;
   r.filter((item) => {
     if (item.id.search(regex) !== -1) {
       keys.push(item.id);
     }
-  }).run(that.connection, callback);
+  }).run(this.connection, callback);
 };
 
 exports.database.prototype.set = function (key, value, callback) {
-  const that = this;
-  r.table(that.table)
+  r.table(this.table)
       .insert({id: key, content: value}, {conflict: 'replace'})
-      .run(that.connection, callback);
+      .run(this.connection, callback);
 };
 
 exports.database.prototype.doBulk = function (bulk, callback) {
-  const that = this;
   const _in = [];
   const _out = [];
 
@@ -85,13 +80,12 @@ exports.database.prototype.doBulk = function (bulk, callback) {
     }
   }
   async.parallel([
-    (cb) => { r.table(that.table).insert(_in, {conflict: 'replace'}).run(that.connection, cb); },
-    (cb) => { r.table(that.table).getAll(_out).delete().run(that.connection, cb); },
+    (cb) => { r.table(this.table).insert(_in, {conflict: 'replace'}).run(this.connection, cb); },
+    (cb) => { r.table(this.table).getAll(_out).delete().run(this.connection, cb); },
   ], callback);
 };
 exports.database.prototype.remove = function (key, callback) {
-  const that = this;
-  r.table(that.table).get(key).delete().run(that.connection, callback);
+  r.table(this.table).get(key).delete().run(this.connection, callback);
 };
 
 exports.database.prototype.close = function (callback) {

--- a/databases/rethink_db.js
+++ b/databases/rethink_db.js
@@ -18,7 +18,7 @@
 const r = require('rethinkdb');
 const async = require('async');
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   if (!settings) settings = {};
   if (!settings.host) { settings.host = 'localhost'; }
   if (!settings.port) { settings.port = 28015; }
@@ -32,7 +32,7 @@ exports.database = function (settings) {
   this.connection = null;
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   r.connect(this, (err, conn) => {
     if (err) throw err;
     this.connection = conn;
@@ -46,13 +46,13 @@ exports.database.prototype.init = function (callback) {
   });
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   r.table(this.table).get(key).run(this.connection, (err, item) => {
     callback(err, (item ? item.content : item));
   });
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const keys = [];
   const regex = this.createFindRegex(key, notKey);
   r.filter((item) => {
@@ -62,13 +62,13 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   }).run(this.connection, callback);
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   r.table(this.table)
       .insert({id: key, content: value}, {conflict: 'replace'})
       .run(this.connection, callback);
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   const _in = [];
   const _out = [];
 
@@ -84,10 +84,10 @@ exports.database.prototype.doBulk = function (bulk, callback) {
     (cb) => { r.table(this.table).getAll(_out).delete().run(this.connection, cb); },
   ], callback);
 };
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   r.table(this.table).get(key).delete().run(this.connection, callback);
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.connection.close(callback);
 };

--- a/databases/sqlite_db.js
+++ b/databases/sqlite_db.js
@@ -29,7 +29,7 @@ const util = require('util');
 
 const escape = (val) => `'${val.replace(/'/g, "''")}'`;
 
-exports.database = function (settings) {
+exports.Database = function (settings) {
   this.db = null;
 
   if (!settings || !settings.filename) {
@@ -50,7 +50,7 @@ exports.database = function (settings) {
   }
 };
 
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   util.callbackify(async () => {
     this.db = await new Promise((resolve, reject) => {
       new sqlite3.Database(this.settings.filename, function (err) {
@@ -65,13 +65,13 @@ exports.database.prototype.init = function (callback) {
   })(callback);
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   this.db.get('SELECT value FROM store WHERE key = ?', key, (err, row) => {
     callback(err, row ? row.value : null);
   });
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   let query = 'SELECT key FROM store WHERE key LIKE ?';
   const params = [];
   // desired keys are %key:%, e.g. pad:%
@@ -98,15 +98,15 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
   });
 };
 
-exports.database.prototype.set = function (key, value, callback) {
+exports.Database.prototype.set = function (key, value, callback) {
   this.db.run('REPLACE INTO store VALUES (?,?)', key, value, callback);
 };
 
-exports.database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = function (key, callback) {
   this.db.run('DELETE FROM store WHERE key = ?', key, callback);
 };
 
-exports.database.prototype.doBulk = function (bulk, callback) {
+exports.Database.prototype.doBulk = function (bulk, callback) {
   let sql = 'BEGIN TRANSACTION;\n';
   for (const i in bulk) {
     if (bulk[i].type === 'set') {
@@ -127,6 +127,6 @@ exports.database.prototype.doBulk = function (bulk, callback) {
   });
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.db.close(callback);
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-/* eslint new-cap: ["error", {"newIsCapExceptions": ["channels", "database"]}] */
+/* eslint new-cap: ["error", {"newIsCapExceptions": ["channels"]}] */
 
 /**
  * 2011 Peter 'Pita' Martischka
@@ -32,7 +32,7 @@ const defaultLogger = {
 /**
  The Constructor
 */
-exports.database = function (type, dbSettings, wrapperSettings, logger) {
+exports.Database = function (type, dbSettings, wrapperSettings, logger) {
   if (!type) {
     type = 'sqlite';
     dbSettings = null;
@@ -48,9 +48,9 @@ exports.database = function (type, dbSettings, wrapperSettings, logger) {
   this.channels = new channels.channels(doOperation);
 };
 
-exports.database.prototype.init = function (callback) {
-  const db = new this.dbModule.database(this.dbSettings);
-  this.db = new cacheAndBufferLayer.database(db, this.wrapperSettings, this.logger);
+exports.Database.prototype.init = function (callback) {
+  const db = new this.dbModule.Database(this.dbSettings);
+  this.db = new cacheAndBufferLayer.Database(db, this.wrapperSettings, this.logger);
   if (callback) {
     this.db.init(callback);
   } else {
@@ -62,32 +62,32 @@ exports.database.prototype.init = function (callback) {
  Wrapper functions
 */
 
-exports.database.prototype.doShutdown = function (callback) {
+exports.Database.prototype.doShutdown = function (callback) {
   this.db.doShutdown(callback);
 };
 
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   this.channels.emit(key, {db: this.db, type: 'get', key, callback});
 };
 
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   this.channels.emit(key, {db: this.db, type: 'findKeys', key, notKey, callback});
 };
 
-exports.database.prototype.remove = function (key, bufferCallback, writeCallback) {
+exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
   this.channels.emit(key, {db: this.db, type: 'remove', key, bufferCallback, writeCallback});
 };
 
-exports.database.prototype.set = function (key, value, bufferCallback, writeCallback) {
+exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
   this.channels.emit(key,
       {db: this.db, type: 'set', key, value: clone(value), bufferCallback, writeCallback});
 };
 
-exports.database.prototype.getSub = function (key, sub, callback) {
+exports.Database.prototype.getSub = function (key, sub, callback) {
   this.channels.emit(key, {db: this.db, type: 'getsub', key, sub, callback});
 };
 
-exports.database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
+exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
   this.channels.emit(key,
       {db: this.db, type: 'setsub', key, sub, value: clone(value), bufferCallback, writeCallback});
 };
@@ -153,7 +153,7 @@ const doOperation = (operation, callback) => {
   }
 };
 
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.db.close(callback);
 };
 
@@ -188,3 +188,8 @@ const clone = (obj) => {
 
   throw new Error("Unable to copy obj! Its type isn't supported.");
 };
+
+/**
+ * Deprecated synonym of Database.
+ */
+exports.database = exports.Database;

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -398,28 +398,28 @@ const flush = (db, callback) => {
   for (const key in db.buffer) {
     if (!Object.prototype.hasOwnProperty.call(db.buffer, key)) continue;
     const entry = db.buffer[key];
-    if (entry.dirty === true) {
-      // collect all data for the operation
-      let value = entry.value;
-      const type = value == null ? 'remove' : 'set';
+    if (entry.dirty !== true) continue;
 
-      // stringify the value if stringifying is enabled
-      if (db.settings.json === true && value != null) value = JSON.stringify(value);
-      else value = clone(value);
+    // collect all data for the operation
+    let value = entry.value;
+    const type = value == null ? 'remove' : 'set';
 
-      // add the operation to the operations array
-      operations.push({type, key, value});
+    // stringify the value if stringifying is enabled
+    if (db.settings.json === true && value != null) value = JSON.stringify(value);
+    else value = clone(value);
 
-      // collect callbacks
-      callbacks = callbacks.concat(entry.callbacks);
+    // add the operation to the operations array
+    operations.push({type, key, value});
 
-      // clean callbacks
-      entry.callbacks = [];
-      // set the dirty flag to false
-      entry.dirty = false;
-      // set the writingInProgress flag to true
-      entry.writingInProgress = true;
-    }
+    // collect callbacks
+    callbacks = callbacks.concat(entry.callbacks);
+
+    // clean callbacks
+    entry.callbacks = [];
+    // set the dirty flag to false
+    entry.dirty = false;
+    // set the writingInProgress flag to true
+    entry.writingInProgress = true;
   }
 
   // send the bulk to the database driver and call the callbacks with the results

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -53,7 +53,7 @@ const defaultSettings =
  @param wrappedDB The Database that should be wrapped
  @param settings (optional) The settings that should be applied to the wrapper
 */
-exports.database = function (wrappedDB, settings, logger) {
+exports.Database = function (wrappedDB, settings, logger) {
   // saved the wrappedDB
   this.wrappedDB = wrappedDB;
   this.logger = logger;
@@ -116,21 +116,21 @@ exports.database = function (wrappedDB, settings, logger) {
 /**
  wraps the init function of the original DB
 */
-exports.database.prototype.init = function (callback) {
+exports.Database.prototype.init = function (callback) {
   this.wrappedDB.init(callback);
 };
 
 /**
  wraps the close function of the original DB
 */
-exports.database.prototype.close = function (callback) {
+exports.Database.prototype.close = function (callback) {
   this.wrappedDB.close(callback);
 };
 
 /**
  Calls the callback the next time all buffers are flushed
 */
-exports.database.prototype.doShutdown = function (callback) {
+exports.Database.prototype.doShutdown = function (callback) {
   // wait until the buffer is fully written
   if (this.settings.writeInterval > 0) this.shutdownCallback = callback;
   // we write direct, so there is no need to wait for a callback
@@ -140,7 +140,7 @@ exports.database.prototype.doShutdown = function (callback) {
 /**
  Gets the value trough the wrapper.
 */
-exports.database.prototype.get = function (key, callback) {
+exports.Database.prototype.get = function (key, callback) {
   const entry = this.buffer[key];
   // if cache is enabled and data is in the cache, get the value from the cache
   if (this.settings.cache > 0 && entry) {
@@ -191,7 +191,7 @@ exports.database.prototype.get = function (key, callback) {
  * Find keys function searches the db sets for matching entries and
  * returns the key entries via callback.
  */
-exports.database.prototype.findKeys = function (key, notKey, callback) {
+exports.Database.prototype.findKeys = function (key, notKey, callback) {
   const bufferKey = `${key}-${notKey}`;
   this.wrappedDB.findKeys(key, notKey, (err, keyValues) => {
     // call the garbage collector
@@ -206,7 +206,7 @@ exports.database.prototype.findKeys = function (key, notKey, callback) {
 /**
  * Remove a record from the database
  */
-exports.database.prototype.remove = function (key, bufferCallback, writeCallback) {
+exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
   this.logger.debug(`DELETE - ${key} - from database `);
 
   this.set(key, null, bufferCallback, writeCallback);
@@ -215,7 +215,7 @@ exports.database.prototype.remove = function (key, bufferCallback, writeCallback
 /**
  Sets the value trough the wrapper
 */
-exports.database.prototype.set = function (key, value, bufferCallback, writeCallback) {
+exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
   // writing cache is enabled, so simply write it into the buffer
   if (this.settings.writeInterval > 0) {
     this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to buffer`);
@@ -272,7 +272,7 @@ exports.database.prototype.set = function (key, value, bufferCallback, writeCall
 /**
  Sets a subvalue
 */
-exports.database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
+exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
   this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
 
   async.waterfall([
@@ -314,7 +314,7 @@ exports.database.prototype.setSub = function (key, sub, value, bufferCallback, w
  * @param sub is a array, for example if you want to access object.test.bla, the array is ["test",
  *     "bla"]
  */
-exports.database.prototype.getSub = function (key, sub, callback) {
+exports.Database.prototype.getSub = function (key, sub, callback) {
   // get the full value
   this.get(key, (err, value) => {
     // there happens an errror while getting this value, call callback
@@ -344,7 +344,7 @@ exports.database.prototype.getSub = function (key, sub, callback) {
 /**
  Garbage Collector of the cache
 */
-exports.database.prototype.gc = function () {
+exports.Database.prototype.gc = function () {
   // If the buffer size is under the settings size or cache is disabled -> return cause there is
   // nothing to do
   if (this.bufferLength < this.settings.cache || this.settings.cache === 0) {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -141,18 +141,18 @@ exports.database.prototype.doShutdown = function (callback) {
  Gets the value trough the wrapper.
 */
 exports.database.prototype.get = function (key, callback) {
+  const entry = this.buffer[key];
   // if cache is enabled and data is in the cache, get the value from the cache
-  if ((this.settings.cache > 0) && this.buffer[key]) {
-    this.logger.debug(`GET    - ${key} - ${JSON.stringify(this.buffer[key].value)} - from cache`);
-    this.buffer[key].timestamp = new Date().getTime();
-    callback(null, this.buffer[key].value);
-  } else if (this.settings.cache === 0 && this.buffer[key] && this.buffer[key].dirty) {
+  if (this.settings.cache > 0 && entry) {
+    this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from cache`);
+    entry.timestamp = new Date().getTime();
+    callback(null, entry.value);
+  } else if (this.settings.cache === 0 && entry && entry.dirty) {
     // caching is disabled but its still in a dirty writing cache, so we have to get the value out
     // of the cache too
-    this.logger.debug(
-        `GET    - ${key} - ${JSON.stringify(this.buffer[key].value)} - from dirty buffer`);
-    this.buffer[key].timestamp = new Date().getTime();
-    callback(null, this.buffer[key].value);
+    this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from dirty buffer`);
+    entry.timestamp = new Date().getTime();
+    callback(null, entry.value);
   } else {
     // get it direct
     this.wrappedDB.get(key, (err, value) => {
@@ -220,16 +220,17 @@ exports.database.prototype.set = function (key, value, bufferCallback, writeCall
   if (this.settings.writeInterval > 0) {
     this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to buffer`);
 
+    let entry = this.buffer[key];
     // initalize the buffer object if it not exists
-    if (!this.buffer[key]) {
-      this.buffer[key] = {};
+    if (!entry) {
+      entry = this.buffer[key] = {};
       this.bufferLength++;
     }
 
     // set the new values
-    this.buffer[key].value = value;
-    this.buffer[key].dirty = true;
-    this.buffer[key].timestamp = new Date().getTime();
+    entry.value = value;
+    entry.dirty = true;
+    entry.timestamp = new Date().getTime();
 
     // call the garbage collector
     this.gc();
@@ -237,11 +238,11 @@ exports.database.prototype.set = function (key, value, bufferCallback, writeCall
     // initalize the callback array in the buffer object if it not exists. we need this as an array,
     // cause the value may be many times overwritten bevors its finally written to the database, but
     // all callbacks must be called
-    if (!this.buffer[key].callbacks) this.buffer[key].callbacks = [];
+    if (!entry.callbacks) entry.callbacks = [];
 
     // add this callback to the array
     if (!writeCallback) writeCallback = (err) => { if (err != null) throw err; };
-    this.buffer[key].callbacks.push(writeCallback);
+    entry.callbacks.push(writeCallback);
 
     // call the buffer callback
     if (bufferCallback) bufferCallback();
@@ -356,10 +357,11 @@ exports.database.prototype.gc = function () {
   // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
   // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
   // (No profiling has been performed however.)
-  for (const i in this.buffer) {
-    if (!Object.prototype.hasOwnProperty.call(this.buffer, i)) continue;
-    if (this.buffer[i].dirty === false && this.buffer[i].writingInProgress === false) {
-      deleteCandidates.push({key: i, timestamp: this.buffer[i].timestamp});
+  for (const key in this.buffer) {
+    if (!Object.prototype.hasOwnProperty.call(this.buffer, key)) continue;
+    const entry = this.buffer[key];
+    if (entry.dirty === false && entry.writingInProgress === false) {
+      deleteCandidates.push({key, timestamp: entry.timestamp});
     }
   }
 
@@ -393,13 +395,13 @@ const flush = (db, callback) => {
   // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
   // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
   // (No profiling has been performed however.)
-  for (const i in db.buffer) {
-    if (!Object.prototype.hasOwnProperty.call(db.buffer, i)) continue;
-    if (db.buffer[i].dirty === true) {
+  for (const key in db.buffer) {
+    if (!Object.prototype.hasOwnProperty.call(db.buffer, key)) continue;
+    const entry = db.buffer[key];
+    if (entry.dirty === true) {
       // collect all data for the operation
-      const type = db.buffer[i].value == null ? 'remove' : 'set';
-      const key = i;
-      let value = db.buffer[i].value;
+      let value = entry.value;
+      const type = value == null ? 'remove' : 'set';
 
       // stringify the value if stringifying is enabled
       if (db.settings.json === true && value != null) value = JSON.stringify(value);
@@ -409,14 +411,14 @@ const flush = (db, callback) => {
       operations.push({type, key, value});
 
       // collect callbacks
-      callbacks = callbacks.concat(db.buffer[i].callbacks);
+      callbacks = callbacks.concat(entry.callbacks);
 
       // clean callbacks
-      db.buffer[i].callbacks = [];
+      entry.callbacks = [];
       // set the dirty flag to false
-      db.buffer[i].dirty = false;
+      entry.dirty = false;
       // set the writingInProgress flag to true
-      db.buffer[i].writingInProgress = true;
+      entry.writingInProgress = true;
     }
   }
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -352,7 +352,12 @@ exports.database.prototype.gc = function () {
 
   // collect all values that are not dirty
   const deleteCandidates = [];
+  // This could instead use `for..of` with `Object.entries`, but `for..in` with
+  // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
+  // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
+  // (No profiling has been performed however.)
   for (const i in this.buffer) {
+    if (!Object.prototype.hasOwnProperty.call(this.buffer, i)) continue;
     if (this.buffer[i].dirty === false && this.buffer[i].writingInProgress === false) {
       deleteCandidates.push({key: i, timestamp: this.buffer[i].timestamp});
     }
@@ -384,8 +389,12 @@ const flush = (db, callback) => {
   const operations = [];
   let callbacks = [];
 
-  // run trough the buffer and search for dirty values
+  // This could instead use `for..of` with `Object.entries`, but `for..in` with
+  // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
+  // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
+  // (No profiling has been performed however.)
   for (const i in db.buffer) {
+    if (!Object.prototype.hasOwnProperty.call(db.buffer, i)) continue;
     if (db.buffer[i].dirty === true) {
       // collect all data for the operation
       const type = db.buffer[i].value == null ? 'remove' : 'set';

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -240,11 +240,8 @@ exports.database.prototype.set = function (key, value, bufferCallback, writeCall
     if (!this.buffer[key].callbacks) this.buffer[key].callbacks = [];
 
     // add this callback to the array
-    if (writeCallback) { this.buffer[key].callbacks.push(writeCallback); } else {
-      this.buffer[key].callbacks.push((err) => {
-        if (err) throw err;
-      });
-    }
+    if (!writeCallback) writeCallback = (err) => { if (err != null) throw err; };
+    this.buffer[key].callbacks.push(writeCallback);
 
     // call the buffer callback
     if (bufferCallback) bufferCallback();

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -364,17 +364,11 @@ exports.database.prototype.gc = function () {
       deleteCandidates.push({key, timestamp: entry.timestamp});
     }
   }
-
-  if (deleteCandidates.length > 0) {
-    // sort them based on the timestamp
-    deleteCandidates.sort((a, b) => a.timestamp - b.timestamp);
-
-    // delete the half buffer
-    for (let i = 0; ((this.bufferLength > this.settings.cache / 2) &&
-                     i < deleteCandidates.length); i++) {
-      delete this.buffer[deleteCandidates[i].key];
-      this.bufferLength--;
-    }
+  deleteCandidates.sort((a, b) => a.timestamp - b.timestamp);
+  for (const {key} of deleteCandidates) {
+    if (this.bufferLength <= this.settings.cache / 2) break;
+    delete this.buffer[key];
+    this.bufferLength--;
   }
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -155,10 +155,8 @@ exports.database.prototype.get = function (key, callback) {
     callback(null, this.buffer[key].value);
   } else {
     // get it direct
-    const self = this;
-
     this.wrappedDB.get(key, (err, value) => {
-      if (self.settings.json) {
+      if (this.settings.json) {
         try {
           value = JSON.parse(value);
         } catch (e) {
@@ -169,20 +167,20 @@ exports.database.prototype.get = function (key, callback) {
       }
 
       // cache the value if caching is enabled
-      if (self.settings.cache > 0) {
-        self.buffer[key] = {
+      if (this.settings.cache > 0) {
+        this.buffer[key] = {
           value,
           dirty: false,
           timestamp: new Date().getTime(),
           writingInProgress: false,
         };
       }
-      self.bufferLength++;
+      this.bufferLength++;
 
       // call the garbage collector
-      self.gc();
+      this.gc();
 
-      self.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
+      this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
 
       callback(err, value);
     });
@@ -195,12 +193,11 @@ exports.database.prototype.get = function (key, callback) {
  */
 exports.database.prototype.findKeys = function (key, notKey, callback) {
   const bufferKey = `${key}-${notKey}`;
-  const self = this;
   this.wrappedDB.findKeys(key, notKey, (err, keyValues) => {
     // call the garbage collector
-    self.gc();
+    this.gc();
 
-    self.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
+    this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
 
     callback(err, keyValues);
   });
@@ -278,14 +275,12 @@ exports.database.prototype.set = function (key, value, bufferCallback, writeCall
  Sets a subvalue
 */
 exports.database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
-  const _this = this;
-
   this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
 
   async.waterfall([
     // get the full value
     (callback) => {
-      _this.get(key, callback);
+      this.get(key, callback);
     },
     // set the sub value and set the full value again
     (fullValue, callback) => {
@@ -304,7 +299,7 @@ exports.database.prototype.setSub = function (key, sub, value, bufferCallback, w
 
       // set the subvalue, we're doing that with the parent element
       subvalueParent[sub[sub.length - 1]] = value;
-      _this.set(key, fullValue, bufferCallback, writeCallback);
+      this.set(key, fullValue, bufferCallback, writeCallback);
       callback(null);
     },
   ], (err) => {
@@ -322,8 +317,6 @@ exports.database.prototype.setSub = function (key, sub, value, bufferCallback, w
  *     "bla"]
  */
 exports.database.prototype.getSub = function (key, sub, callback) {
-  const _this = this;
-
   // get the full value
   this.get(key, (err, value) => {
     // there happens an errror while getting this value, call callback
@@ -344,7 +337,7 @@ exports.database.prototype.getSub = function (key, sub, callback) {
         }
       }
 
-      _this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+      this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
       callback(err, subvalue);
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ueberdb2",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "url": "https://github.com/ether/ueberDB.git"
   },
   "main": "./index",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/ether/ueberDB/issues"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 'use strict';
-/* eslint new-cap: ["error", {"newIsCapExceptions": ["database"]}] */
 
 const wtfnode = require('wtfnode'); // This should be first so that it can instrument everything.
 
@@ -59,7 +58,7 @@ describe(__filename, function () {
 
           before(async function () {
             if (dbSettings.filename) await fs.unlink(dbSettings.filename).catch(() => {});
-            db = new ueberdb.database(database, dbSettings);
+            db = new ueberdb.Database(database, dbSettings);
             await util.promisify(db.init.bind(db))();
             if (!cacheEnabled) db.cache = 0;
           });


### PR DESCRIPTION
There should be no behavior change with this PR.

Multiple commits:
* Use `this` instead of `self`, `_this`, or `that`
* cache: Simplify write callback conditional
* cache: Avoid iterating over inherited properties
* cache: Avoid repeated key lookups
* cache: Invert the dirty check (for readability)
* cache: Simplify `gc()` delete loop
* Rename `database` constructors to `Database`
* cassandra: Use template literal instead of `util.format()`
