### PR TITLE
Minor cache fixes and cleanups

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -345,7 +345,7 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
  Garbage Collector of the cache
 */
 exports.Database.prototype.gc = function () {
-  if (this.bufferLength <= this.settings.cache || this.settings.cache === 0) return;
+  if (this.bufferLength <= this.settings.cache) return;
 
   // collect all values that are not dirty
   const deleteCandidates = [];

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -142,15 +142,9 @@ exports.Database.prototype.doShutdown = function (callback) {
 */
 exports.Database.prototype.get = function (key, callback) {
   const entry = this.buffer[key];
-  // if cache is enabled and data is in the cache, get the value from the cache
-  if (this.settings.cache > 0 && entry) {
-    this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from cache`);
-    entry.timestamp = new Date().getTime();
-    callback(null, entry.value);
-  } else if (this.settings.cache === 0 && entry && entry.dirty) {
-    // caching is disabled but its still in a dirty writing cache, so we have to get the value out
-    // of the cache too
-    this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - from dirty buffer`);
+  if (entry != null) {
+    this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
+                      `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
     entry.timestamp = new Date().getTime();
     callback(null, entry.value);
   } else {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -362,7 +362,7 @@ exports.Database.prototype.gc = function () {
   }
   deleteCandidates.sort((a, b) => a.timestamp - b.timestamp);
   for (const {key} of deleteCandidates) {
-    if (this.bufferLength <= this.settings.cache / 2) break;
+    if (this.bufferLength <= this.settings.cache) break;
     delete this.buffer[key];
     this.bufferLength--;
   }

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -146,39 +146,38 @@ exports.Database.prototype.get = function (key, callback) {
     this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
                       `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
     entry.timestamp = new Date().getTime();
-    callback(null, entry.value);
-  } else {
-    // get it direct
-    this.wrappedDB.get(key, (err, value) => {
-      if (this.settings.json) {
-        try {
-          value = JSON.parse(value);
-        } catch (e) {
-          console.error(`JSON-PROBLEM:${value}`);
-          callback(e);
-          return;
-        }
-      }
-
-      // cache the value if caching is enabled
-      if (this.settings.cache > 0) {
-        this.buffer[key] = {
-          value,
-          dirty: false,
-          timestamp: new Date().getTime(),
-          writingInProgress: false,
-        };
-      }
-      this.bufferLength++;
-
-      // call the garbage collector
-      this.gc();
-
-      this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
-
-      callback(err, value);
-    });
+    return callback(null, entry.value);
   }
+  // get it direct
+  this.wrappedDB.get(key, (err, value) => {
+    if (this.settings.json) {
+      try {
+        value = JSON.parse(value);
+      } catch (e) {
+        console.error(`JSON-PROBLEM:${value}`);
+        callback(e);
+        return;
+      }
+    }
+
+    // cache the value if caching is enabled
+    if (this.settings.cache > 0) {
+      this.buffer[key] = {
+        value,
+        dirty: false,
+        timestamp: new Date().getTime(),
+        writingInProgress: false,
+      };
+    }
+    this.bufferLength++;
+
+    // call the garbage collector
+    this.gc();
+
+    this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
+
+    callback(err, value);
+  });
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -91,7 +91,7 @@ exports.Database = function (wrappedDB, settings, logger) {
 
   // start the write Interval
   this.flushInterval = this.settings.writeInterval > 0
-    ? setInterval(() => flush(this), this.settings.writeInterval) : null;
+    ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
 
   // set the flushing flag to false, this flag shows that there is a flushing action happing at the
   // moment
@@ -375,9 +375,9 @@ exports.Database.prototype.gc = function () {
 /**
  Writes all dirty values to the database
 */
-const flush = (db, callback) => {
+exports.Database.prototype.flush = function (callback) {
   // return if there is a flushing action in process
-  if (db.isFlushing) {
+  if (this.isFlushing) {
     if (callback) callback();
     return;
   }
@@ -389,9 +389,9 @@ const flush = (db, callback) => {
   // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
   // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
   // (No profiling has been performed however.)
-  for (const key in db.buffer) {
-    if (!Object.prototype.hasOwnProperty.call(db.buffer, key)) continue;
-    const entry = db.buffer[key];
+  for (const key in this.buffer) {
+    if (!Object.prototype.hasOwnProperty.call(this.buffer, key)) continue;
+    const entry = this.buffer[key];
     if (entry.dirty !== true) continue;
 
     // collect all data for the operation
@@ -399,7 +399,7 @@ const flush = (db, callback) => {
     const type = value == null ? 'remove' : 'set';
 
     // stringify the value if stringifying is enabled
-    if (db.settings.json === true && value != null) value = JSON.stringify(value);
+    if (this.settings.json === true && value != null) value = JSON.stringify(value);
     else value = clone(value);
 
     // add the operation to the operations array
@@ -419,9 +419,9 @@ const flush = (db, callback) => {
   // send the bulk to the database driver and call the callbacks with the results
   if (operations.length > 0) {
     // set the flushing flag
-    db.isFlushing = true;
+    this.isFlushing = true;
 
-    db.wrappedDB.doBulk(operations, (err) => {
+    this.wrappedDB.doBulk(operations, (err) => {
       // call all writingCallbacks
       for (const cb of callbacks) {
         cb(err);
@@ -429,22 +429,22 @@ const flush = (db, callback) => {
 
       // set the writingInProgress flag to false
       for (const {key} of operations) {
-        db.buffer[key].writingInProgress = false;
+        this.buffer[key].writingInProgress = false;
       }
 
       if (callback) callback();
 
       // call the garbage collector
-      db.gc();
+      this.gc();
 
       // set the flushing flag to false
-      db.isFlushing = false;
+      this.isFlushing = false;
     });
-  } else if (db.shutdownCallback != null) {
+  } else if (this.shutdownCallback != null) {
     // the writing buffer is empty and there is a shutdown callback, call it!
-    clearInterval(db.flushInterval);
-    db.shutdownCallback();
-    db.shutdownCallback = null;
+    clearInterval(this.flushInterval);
+    this.shutdownCallback();
+    this.shutdownCallback = null;
   }
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -345,11 +345,7 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
  Garbage Collector of the cache
 */
 exports.Database.prototype.gc = function () {
-  // If the buffer size is under the settings size or cache is disabled -> return cause there is
-  // nothing to do
-  if (this.bufferLength < this.settings.cache || this.settings.cache === 0) {
-    return;
-  }
+  if (this.bufferLength <= this.settings.cache || this.settings.cache === 0) return;
 
   // collect all values that are not dirty
   const deleteCandidates = [];


### PR DESCRIPTION
Multiple commits:
* cache: Convert `flush()` function to a method
* cache: Fix off-by-one bug in `gc()`
* cache: Run `gc()` even if read cache is disabled
* cache: Fix overly aggressive cache entry deletion in `gc()`
* cache: Simplify cache check in `get()`
* cache: Return from `get()` early if there is a cache entry
