### PR TITLE
More minor cache fixes and cleanups

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -238,7 +238,7 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
     entry.callbacks.push(writeCallback);
 
     // call the buffer callback
-    if (bufferCallback) bufferCallback();
+    if (bufferCallback) setImmediate(bufferCallback);
   } else {
     // writecache is disabled, so we write directly to the database
     this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to database`);

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -429,7 +429,10 @@ exports.Database.prototype.flush = function (callback) {
       // set the flushing flag to false
       this.isFlushing = false;
     });
-  } else if (this.shutdownCallback != null) {
+    return;
+  }
+  if (callback) setImmediate(callback);
+  if (this.shutdownCallback != null) {
     // the writing buffer is empty and there is a shutdown callback, call it!
     clearInterval(this.flushInterval);
     this.shutdownCallback();

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -255,7 +255,7 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
     } else {
       // thats a correct value
       // stringify the value if stringifying is enabled
-      if (this.settings.json === true) value = JSON.stringify(value);
+      if (this.settings.json) value = JSON.stringify(value);
 
       this.wrappedDB.set(key, value, callback);
     }
@@ -349,7 +349,7 @@ exports.Database.prototype.gc = function () {
   for (const key in this.buffer) {
     if (!Object.prototype.hasOwnProperty.call(this.buffer, key)) continue;
     const entry = this.buffer[key];
-    if (entry.dirty === false && entry.writingInProgress === false) {
+    if (!entry.dirty && !entry.writingInProgress) {
       deleteCandidates.push({key, timestamp: entry.timestamp});
     }
   }
@@ -381,14 +381,14 @@ exports.Database.prototype.flush = function (callback) {
   for (const key in this.buffer) {
     if (!Object.prototype.hasOwnProperty.call(this.buffer, key)) continue;
     const entry = this.buffer[key];
-    if (entry.dirty !== true) continue;
+    if (!entry.dirty) continue;
 
     // collect all data for the operation
     let value = entry.value;
     const type = value == null ? 'remove' : 'set';
 
     // stringify the value if stringifying is enabled
-    if (this.settings.json === true && value != null) value = JSON.stringify(value);
+    if (this.settings.json && value != null) value = JSON.stringify(value);
     else value = clone(value);
 
     // add the operation to the operations array


### PR DESCRIPTION
Multiple commits:
* cache: Call `bufferCallback` asynchronously
* cache: Don't compare with true or false, just use truthiness
* cache: Always call the callback passed to `flush()`
