### PR TITLE
cache: Redo write logic to fix a corner case

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -214,61 +214,43 @@ exports.Database.prototype.remove = function (key, bufferCallback, writeCallback
  Sets the value trough the wrapper
 */
 exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
-  // writing cache is enabled, so simply write it into the buffer
-  if (this.settings.writeInterval > 0) {
-    if (this.logger.isDebugEnabled()) {
-      this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to buffer`);
-    }
-
-    let entry = this.buffer[key];
-    // initalize the buffer object if it not exists
-    if (!entry) {
-      entry = this.buffer[key] = {};
-      this.bufferLength++;
-    }
-
-    // set the new values
+  let entry = this.buffer[key];
+  // If there is a write of a different value for the same key already in progress then don't update
+  // the existing entry object -- create a new entry object instead and replace the old one in
+  // this.buffer. This ensures that the writeCallback for the new value is not called until after
+  // the new value is written. (If the existing entry is updated instead, then the writeCallback for
+  // the new value would be called when the old value is committed, not when the new value is
+  // committed.)
+  if (!entry || (entry.writingInProgress && entry.value !== value)) {
+    // Only update this.bufferLength when a new entry is going to be added to this.buffer, not when
+    // an existing entry is going to be replaced. This ensures an accurate count of the number of
+    // entries in this.buffer, but it undercounts the number of entries that exist in memory:
+    // Whenever there is an write in progress and the value is updated by a call to set(), there
+    // will be two entries in memory for the same key: the in-progress entry (this._write() holds a
+    // reference to that entry) and a dirty entry in this.buffer.
+    if (!entry) this.bufferLength++;
+    entry = this.buffer[key] = {value, dirty: true};
+  } else if (entry.value !== value) {
     entry.value = value;
     entry.dirty = true;
-    entry.timestamp = new Date().getTime();
-
-    // call the garbage collector
-    this.gc();
-
-    // initalize the callback array in the buffer object if it not exists. we need this as an array,
-    // cause the value may be many times overwritten bevors its finally written to the database, but
-    // all callbacks must be called
-    if (!entry.callbacks) entry.callbacks = [];
-
-    // add this callback to the array
-    if (!writeCallback) writeCallback = (err) => { if (err != null) throw err; };
-    entry.callbacks.push(writeCallback);
-
-    // call the buffer callback
-    if (bufferCallback) setImmediate(bufferCallback);
-  } else {
-    // writecache is disabled, so we write directly to the database
-    if (this.logger.isDebugEnabled()) {
-      this.logger.debug(`SET    - ${key} - ${JSON.stringify(value)} - to database`);
-    }
-
-    // create a wrapper callback for write and buffer callback
-    const callback = (err) => {
-      if (bufferCallback) bufferCallback(err);
-      if (writeCallback) writeCallback(err);
-    };
-
-    // The value is null, means this no set operation, this is a remove operation
-    if (value == null) {
-      this.wrappedDB.remove(key, callback);
-    } else {
-      // thats a correct value
-      // stringify the value if stringifying is enabled
-      if (this.settings.json) value = JSON.stringify(value);
-
-      this.wrappedDB.set(key, value, callback);
-    }
   }
+  entry.timestamp = new Date().getTime();
+  if (bufferCallback) setImmediate(bufferCallback);
+  if (!entry.dirty) {
+    if (writeCallback) setImmediate(writeCallback);
+    return;
+  }
+  this.gc();
+  if (!entry.callbacks) entry.callbacks = [];
+  entry.callbacks.push(writeCallback || ((err) => { if (err != null) throw err; }));
+  const buffered = this.settings.writeInterval > 0;
+  if (this.logger.isDebugEnabled()) {
+    this.logger.debug(
+        `SET    - ${key} - ${JSON.stringify(value)} - to ${buffered ? 'buffer' : 'database'}`);
+  }
+  // Write it immediately if write buffering is disabled. If write buffering is enabled,
+  // this.flush() will eventually take care of it.
+  if (!buffered) this._write([[key, entry]]);
 };
 
 /**
@@ -383,10 +365,7 @@ exports.Database.prototype.flush = function (callback) {
     if (callback) callback();
     return;
   }
-
-  const operations = [];
-  let callbacks = [];
-
+  const dirtyEntries = [];
   // This could instead use `for..of` with `Object.entries`, but `for..in` with
   // `Object.prototype.hasOwnProperty` avoids the overhead of creating an array with all of the
   // entries. The buffer object could have hundreds of entries, so the overhead could be noticeable.
@@ -395,52 +374,13 @@ exports.Database.prototype.flush = function (callback) {
     if (!Object.prototype.hasOwnProperty.call(this.buffer, key)) continue;
     const entry = this.buffer[key];
     if (!entry.dirty) continue;
-
-    // collect all data for the operation
-    let value = entry.value;
-    const type = value == null ? 'remove' : 'set';
-
-    // stringify the value if stringifying is enabled
-    if (this.settings.json && value != null) value = JSON.stringify(value);
-    else value = clone(value);
-
-    // add the operation to the operations array
-    operations.push({type, key, value});
-
-    // collect callbacks
-    callbacks = callbacks.concat(entry.callbacks);
-
-    // clean callbacks
-    entry.callbacks = [];
-    // set the dirty flag to false
-    entry.dirty = false;
-    // set the writingInProgress flag to true
-    entry.writingInProgress = true;
+    dirtyEntries.push([key, entry]);
   }
-
-  // send the bulk to the database driver and call the callbacks with the results
-  if (operations.length > 0) {
-    // set the flushing flag
+  if (dirtyEntries.length > 0) {
     this.isFlushing = true;
-
-    this.wrappedDB.doBulk(operations, (err) => {
-      // call all writingCallbacks
-      for (const cb of callbacks) {
-        cb(err);
-      }
-
-      // set the writingInProgress flag to false
-      for (const {key} of operations) {
-        this.buffer[key].writingInProgress = false;
-      }
-
-      if (callback) callback();
-
-      // call the garbage collector
-      this.gc();
-
-      // set the flushing flag to false
+    this._write(dirtyEntries, (err) => {
       this.isFlushing = false;
+      if (callback) callback(err);
     });
     return;
   }
@@ -450,6 +390,61 @@ exports.Database.prototype.flush = function (callback) {
     clearInterval(this.flushInterval);
     this.shutdownCallback();
     this.shutdownCallback = null;
+  }
+};
+
+exports.Database.prototype._write = function (dirtyEntries, callback = null) {
+  if (dirtyEntries.length === 0) {
+    if (callback) setImmediate(callback);
+    return;
+  }
+  const writtenCallback = (err) => {
+    for (const [, entry] of dirtyEntries) {
+      entry.writingInProgress = false;
+      // setImmediate() is used to address a corner case: If setImmediate() was not used and one of
+      // these callbacks called set() for the same key but a different value, the new callback
+      // passed to set() would be immediately added to this entry.callbacks list and thus called
+      // prematurely.
+      //
+      // An alternative approach to address the same corner case: Set writingInProgress to false
+      // *after* calling the callbacks, not before. This would cause set() to generate a new dirty
+      // entry (and thus an independent callback list) for the key. There are a few disadvantages to
+      // this alternative approach:
+      //   * writingInProgress will be true while the callbacks are running even though the write
+      //     has completed. That could be confusing when debugging.
+      //   * If set() is called for the same key as this entry but with a different value, two
+      //     entries for the same key will briefly exist at the same time: One referenced here (in
+      //     the dirtyEntries list) and one saved in this.buffer.
+      //   * If set() is called for the same key as this entry and with the same value, the
+      //     callbacks list for this entry will be mutated during iteration. In general, it is
+      //     dangerous to mutate a container during iteration (doing so is a code smell).
+      for (const cb of entry.callbacks) setImmediate(() => cb(err));
+      entry.callbacks.length = 0;
+    }
+    if (callback) callback();
+    this.gc();
+  };
+  const ops = dirtyEntries.map(([key, entry]) => {
+    entry.dirty = false;
+    entry.writingInProgress = true;
+    const value = this.settings.json && entry.value != null
+      ? JSON.stringify(entry.value) : clone(entry.value);
+    return {type: entry.value == null ? 'remove' : 'set', key, value};
+  });
+  if (ops.length === 1) {
+    const {type, key, value} = ops[0];
+    switch (type) {
+      case 'remove':
+        this.wrappedDB.remove(key, writtenCallback);
+        break;
+      case 'set':
+        this.wrappedDB.set(key, value, writtenCallback);
+        break;
+      default:
+        throw new Error(`unsupported operation type: ${type}`);
+    }
+  } else {
+    this.wrappedDB.doBulk(ops, writtenCallback);
   }
 };
 


### PR DESCRIPTION
  * Always stage writes in `this.buffer` even if write buffering is disabled. This ensures that a call to `get()` always sees the most recently set value.
  * Factor out write logic that is identical in `set()` and `flush()`.
  * Avoid an unnecessary write when the new value is already in the database.