### PR TITLE
mssql: Use a semver range for the mssql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "elasticsearch": "^16.7.1",
     "mocha": "^7.1.2",
     "mongodb": "^3.6.3",
-    "mssql": "7.0.0-alpha.4",
+    "mssql": "^7.0.0-alpha.4",
     "mysql": "2.18.1",
     "nano": "^8.2.2",
     "pg": "^8.0.3",


### PR DESCRIPTION
This ensures that `npm up` will upgrade to 7.0.0 once it is released. (The API is unlikely to change before then so this is OK.)