### PR TITLE
Flush improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Notable Changes
+
+## v1.1.10
+
+* Major performance improvement: The caching logic was rewritten with much more
+  efficient algorithms. Also: Scans for entries to evict is performed less
+  often. Depending on your workload you might observe a slight memory usage
+  increase.
+
+## v1.1.7
+
+* `mysql` dependency bumped to 7.0.0-alpha4 to avoid a security vulnerability in
+  one of its indirect dependencies.
+
+## v1.1.6
+
+* Bug fix: When write buffering is disabled, reads of keys with values that were
+  changed but not yet written to the underlying database used to return the
+  previous value. Now the updated value is returned.
+* Minor performance improvement: Setting a key to the same value no longer
+  triggers a database write.
+
+## v1.1.5
+
+* Minor performance improvement: Debug log message strings are no longer
+  generated if debug logging is not enabled.
+
+## v1.1.1
+
+* The `database()` constructor is deprecated; use `Database()` instead.
+
+## Older
+
+See the Git history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Notable Changes
 
-## v1.1.11
+## v1.2.1
 
+* New `flush()` method.
 * The `close()` method now flushes unwritten entries before closing the database
   connection.
 * Bug fix: `null`/`undefined` is no longer cached if there is an error reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Notable Changes
 
+## v1.1.11
+
+* Bug fix: `null`/`undefined` is no longer cached if there is an error reading
+  from the database.
+
 ## v1.1.10
 
 * Major performance improvement: The caching logic was rewritten with much more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.1.11
 
+* The `close()` method now flushes unwritten entries before closing the database
+  connection.
 * Bug fix: `null`/`undefined` is no longer cached if there is an error reading
   from the database.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.2.1
 
 * New `flush()` method.
+* The `doShutdown()` method is deprecated. Use `flush()` instead.
 * The `close()` method now flushes unwritten entries before closing the database
   connection.
 * Bug fix: `null`/`undefined` is no longer cached if there is an error reading

--- a/index.js
+++ b/index.js
@@ -167,6 +167,10 @@ const doOperation = (operation, callback) => {
   }
 };
 
+/**
+ * Flushes unwritten changes then closes the connection to the underlying database. After this
+ * returns, any future call to a method on this object may result in an error.
+ */
 exports.Database.prototype.close = function (callback) {
   this.db.close(callback);
 };

--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ exports.Database.prototype.init = function (callback) {
  Wrapper functions
 */
 
+/**
+ * Deprecated synonym of flush().
+ */
 exports.Database.prototype.doShutdown = function (callback) {
   this.flush(callback);
 };

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ exports.Database.prototype.init = function (callback) {
 */
 
 exports.Database.prototype.doShutdown = function (callback) {
-  this.db.doShutdown(callback);
+  this.db.flush(callback);
 };
 
 exports.Database.prototype.get = function (key, callback) {

--- a/index.js
+++ b/index.js
@@ -77,6 +77,13 @@ exports.Database.prototype.init = function (callback) {
 */
 
 exports.Database.prototype.doShutdown = function (callback) {
+  this.flush(callback);
+};
+
+/**
+ * Writes any unsaved changes to the underlying database.
+ */
+exports.Database.prototype.flush = function (callback) {
   this.db.flush(callback);
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -189,6 +189,7 @@ exports.Database.prototype.init = function (callback) {
  wraps the close function of the original DB
 */
 exports.Database.prototype.close = function (callback) {
+  clearInterval(this.flushInterval);
   this.wrappedDB.close(callback);
 };
 
@@ -399,7 +400,6 @@ exports.Database.prototype.flush = function (callback = null) {
   if (dirtyEntries.length === 0) {
     setImmediate(() => this._callFlushDoneCallbacks());
     if (this.shutdownCallback != null) {
-      clearInterval(this.flushInterval);
       this.shutdownCallback();
       this.shutdownCallback = null;
     }

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -190,7 +190,10 @@ exports.Database.prototype.init = function (callback) {
 */
 exports.Database.prototype.close = function (callback) {
   clearInterval(this.flushInterval);
-  this.wrappedDB.close(callback);
+  this.flush((err) => {
+    if (err != null) return callback(err);
+    this.wrappedDB.close(callback);
+  });
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -217,6 +217,7 @@ exports.Database.prototype.get = function (key, callback) {
   }
   // get it direct
   this.wrappedDB.get(key, (err, value) => {
+    if (err != null) return callback(err || new Error(err));
     if (this.settings.json) {
       try {
         value = JSON.parse(value);
@@ -240,7 +241,7 @@ exports.Database.prototype.get = function (key, callback) {
       this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
     }
 
-    callback(err, value);
+    callback(null, value);
   });
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -159,9 +159,8 @@ exports.Database = function (wrappedDB, settings, logger) {
   this.flushInterval = this.settings.writeInterval > 0
     ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
 
-  // set the flushing flag to false, this flag shows that there is a flushing action happing at the
-  // moment
   this.isFlushing = false;
+  this._flushDoneCallbacks = [];
 
   /**
    * Adds function to db wrapper for findKey regex.
@@ -381,21 +380,24 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
   });
 };
 
+exports.Database.prototype._callFlushDoneCallbacks = function (err) {
+  const callbacks = this._flushDoneCallbacks;
+  this._flushDoneCallbacks = []; // In case a callback calls flush().
+  for (const cb of callbacks) cb(err);
+};
+
 /**
  Writes all dirty values to the database
 */
-exports.Database.prototype.flush = function (callback) {
-  // return if there is a flushing action in process
-  if (this.isFlushing) {
-    if (callback) setImmediate(callback);
-    return;
-  }
+exports.Database.prototype.flush = function (callback = null) {
+  if (callback) this._flushDoneCallbacks.push(callback);
+  if (this.isFlushing) return;
   const dirtyEntries = [];
   for (const entry of this.buffer) {
     if (entry[1].dirty) dirtyEntries.push(entry);
   }
   if (dirtyEntries.length === 0) {
-    if (callback) setImmediate(callback);
+    setImmediate(() => this._callFlushDoneCallbacks());
     if (this.shutdownCallback != null) {
       clearInterval(this.flushInterval);
       this.shutdownCallback();
@@ -406,10 +408,10 @@ exports.Database.prototype.flush = function (callback) {
   this.isFlushing = true;
   this._write(dirtyEntries, (err) => {
     this.isFlushing = false;
-    if (err != null) return callback(err);
+    if (err != null) return this._callFlushDoneCallbacks(err);
     // Recurse in case new dirty entries were created while writing these dirty entries. Once there
     // are no more dirty entries, the base case above will trigger.
-    this.flush(callback);
+    this.flush();
   });
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -197,16 +197,6 @@ exports.Database.prototype.close = function (callback) {
 };
 
 /**
- Calls the callback the next time all buffers are flushed
-*/
-exports.Database.prototype.doShutdown = function (callback) {
-  // wait until the buffer is fully written
-  if (this.settings.writeInterval > 0) this.shutdownCallback = callback;
-  // we write direct, so there is no need to wait for a callback
-  else callback();
-};
-
-/**
  Gets the value trough the wrapper.
 */
 exports.Database.prototype.get = function (key, callback) {
@@ -402,10 +392,6 @@ exports.Database.prototype.flush = function (callback = null) {
   }
   if (dirtyEntries.length === 0) {
     setImmediate(() => this._callFlushDoneCallbacks());
-    if (this.shutdownCallback != null) {
-      this.shutdownCallback();
-      this.shutdownCallback = null;
-    }
     return;
   }
   this.isFlushing = true;

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -394,21 +394,23 @@ exports.Database.prototype.flush = function (callback) {
   for (const entry of this.buffer) {
     if (entry[1].dirty) dirtyEntries.push(entry);
   }
-  if (dirtyEntries.length > 0) {
-    this.isFlushing = true;
-    this._write(dirtyEntries, (err) => {
-      this.isFlushing = false;
-      if (callback) callback(err);
-    });
+  if (dirtyEntries.length === 0) {
+    if (callback) setImmediate(callback);
+    if (this.shutdownCallback != null) {
+      clearInterval(this.flushInterval);
+      this.shutdownCallback();
+      this.shutdownCallback = null;
+    }
     return;
   }
-  if (callback) setImmediate(callback);
-  if (this.shutdownCallback != null) {
-    // the writing buffer is empty and there is a shutdown callback, call it!
-    clearInterval(this.flushInterval);
-    this.shutdownCallback();
-    this.shutdownCallback = null;
-  }
+  this.isFlushing = true;
+  this._write(dirtyEntries, (err) => {
+    this.isFlushing = false;
+    if (err != null) return callback(err);
+    // Recurse in case new dirty entries were created while writing these dirty entries. Once there
+    // are no more dirty entries, the base case above will trigger.
+    this.flush(callback);
+  });
 };
 
 exports.Database.prototype._write = function (dirtyEntries, callback = null) {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -387,7 +387,7 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
 exports.Database.prototype.flush = function (callback) {
   // return if there is a flushing action in process
   if (this.isFlushing) {
-    if (callback) callback();
+    if (callback) setImmediate(callback);
     return;
   }
   const dirtyEntries = [];

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -412,15 +412,17 @@ exports.Database.prototype._write = function (dirtyEntries, callback = null) {
   const writtenCallback = (err) => {
     for (const [, entry] of dirtyEntries) {
       entry.writingInProgress = false;
-      // setImmediate() is used to address a corner case: If setImmediate() was not used and one of
-      // these callbacks called set() for the same key but a different value, the new callback
-      // passed to set() would be immediately added to this entry.callbacks list and thus called
+      // entry.callbacks must be set to [] before the callbacks are called to avoid a problematic
+      // corner case: If a callback called set() for the same key but a different value, the new
+      // callback passed to set() would be immediately added to entry.callbacks and called
       // prematurely.
       //
-      // An alternative approach to address the same corner case: Set writingInProgress to false
-      // *after* calling the callbacks, not before. This would cause set() to generate a new dirty
-      // entry (and thus an independent callback list) for the key. There are a few disadvantages to
-      // this alternative approach:
+      // An alternative approach that would also work: Call the callbacks via setImmediate(). This
+      // adds a bit of overhead, and it might make stack traces less useful.
+      //
+      // Another alternative: Set writingInProgress to false *after* calling the callbacks, not
+      // before. This would cause set() to generate a new dirty entry (and thus an independent
+      // callback list) for the key. There are some minor disadvantages to this approach:
       //   * writingInProgress will be true while the callbacks are running even though the write
       //     has completed. That could be confusing when debugging.
       //   * If set() is called for the same key as this entry but with a different value, two
@@ -429,8 +431,9 @@ exports.Database.prototype._write = function (dirtyEntries, callback = null) {
       //   * If set() is called for the same key as this entry and with the same value, the
       //     callbacks list for this entry will be mutated during iteration. In general, it is
       //     dangerous to mutate a container during iteration (doing so is a code smell).
-      for (const cb of entry.callbacks) setImmediate(() => cb(err));
-      entry.callbacks.length = 0;
+      const callbacks = entry.callbacks;
+      entry.callbacks = [];
+      for (const cb of callbacks) cb(err);
     }
     if (callback) callback();
     // At this point we could call db.buffer.evictOld() to ensure that the number of entries in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ueberdb2",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "url": "https://github.com/ether/ueberDB.git"
   },
   "main": "./index",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "bugs": {
     "url": "https://github.com/ether/ueberDB/issues"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -99,7 +99,6 @@ describe(__filename, function () {
               });
 
               after(async function () {
-                await util.promisify(db.doShutdown.bind(db))();
                 await util.promisify(db.close.bind(db))();
                 if (dbSettings.filename) await fs.unlink(dbSettings.filename).catch(() => {});
               });

--- a/test/test.js
+++ b/test/test.js
@@ -94,8 +94,7 @@ describe(__filename, function () {
                   wp.buffered = bp;
                   return wp;
                 };
-                // TODO: Add a flush() method to ueberdb.Database.
-                flush = util.promisify(db.db.flush.bind(db.db));
+                flush = util.promisify(db.flush.bind(db));
               });
 
               after(async function () {


### PR DESCRIPTION
Multiple commits:
* Add `CHANGELOG.md`
* cache: Return early if there is an error
* cache: Call `flush()` callback asynchronously
* cache: Recursively call `flush()` to drain all dirty entries
* cache: Only call `flush()` callback after flushing is done
* cache: Stop periodic flushes in `close()`, not `doShutdown()`
* cache: Flush entries before closing the db
* cache: Flush immediately upon `doShutdown()`
* cache: Re-think how the write callbacks are called
* New `flush()` method
* Deprecate `doShutdown()` in favor of `flush()`

Fixes #74.