### PR TITLE
cache: Fix `setSub()` corner cases

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -313,22 +313,27 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
     },
     // set the sub value and set the full value again
     (fullValue, callback) => {
-      // get the subvalue parent
-      let subvalueParent = fullValue;
-      for (let i = 0; i < (sub.length - 1); i++) {
-        // test if the subvalue exist
-        if (subvalueParent != null && subvalueParent[sub[i]] !== undefined) {
-          subvalueParent = subvalueParent[sub[i]];
-        } else {
-          // the subvalue doesn't exist, create it
-          subvalueParent[sub[i]] = {};
-          subvalueParent = subvalueParent[sub[i]];
+      const base = {fullValue};
+      // Emulate a pointer to the property that should be set to `value`.
+      const ptr = {obj: base, prop: 'fullValue'};
+      for (let i = 0; i < sub.length; i++) {
+        let o = ptr.obj[ptr.prop];
+        if (o == null) ptr.obj[ptr.prop] = o = {};
+        // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
+        // ECMAScript automatically wraps primitives in a temporary wrapper object.
+        if (typeof o !== 'object') {
+          callback(new TypeError(
+              `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
+              `(key: ${JSON.stringify(key)} ` +
+              `value in db: ${JSON.stringify(fullValue)} ` +
+              `sub: ${JSON.stringify(sub.slice(0, i + 1))})`));
+          return;
         }
+        ptr.obj = ptr.obj[ptr.prop];
+        ptr.prop = sub[i];
       }
-
-      // set the subvalue, we're doing that with the parent element
-      subvalueParent[sub[sub.length - 1]] = value;
-      this.set(key, fullValue, bufferCallback, writeCallback);
+      ptr.obj[ptr.prop] = value;
+      this.set(key, base.fullValue, bufferCallback, writeCallback);
       callback(null);
     },
   ], (err) => {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -334,8 +334,8 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
   ], (err) => {
     if (err) {
       if (bufferCallback) bufferCallback(err);
-      else if (writeCallback) writeCallback(err);
-      else throw err;
+      if (writeCallback) writeCallback(err);
+      if (!bufferCallback && !writeCallback) throw err;
     }
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -245,15 +245,22 @@ describe(__filename, function () {
                   (timers.remove - timers.start) / count,
                 ]);
 
+                // Removes the "Acceptable ms/op" column if there is no enforced limit.
+                const filterColumn = (row) => {
+                  if (readCache && writeBuffer) return row;
+                  row.splice(1, 1);
+                  return row;
+                };
                 const acceptableTable = new Clitable({
-                  head: ['op', 'Acceptable ms/op', 'Actual ms/op'],
-                  colWidths: [10, 18, 18],
+                  head: filterColumn(['op', 'Acceptable ms/op', 'Actual ms/op']),
+                  colWidths: filterColumn([10, 18, 18]),
                 });
-                acceptableTable.push(
-                    ['set', setMax, timePerOp.set],
-                    ['get', getMax, timePerOp.get],
-                    ['findKeys', findKeysMax, timePerOp.findKeys],
-                    ['remove', removeMax, timePerOp.remove]);
+                acceptableTable.push(...[
+                  ['set', setMax, timePerOp.set],
+                  ['get', getMax, timePerOp.get],
+                  ['findKeys', findKeysMax, timePerOp.findKeys],
+                  ['remove', removeMax, timePerOp.remove],
+                ].map(filterColumn));
                 console.log(acceptableTable.toString());
 
                 if (readCache && writeBuffer) {

--- a/test/test.js
+++ b/test/test.js
@@ -218,14 +218,34 @@ describe(__filename, function () {
 
                 await pdb.setSub('k', ['sub1'], 'v2');
                 assert.deepEqual(await pdb.get('k'), {sub1: 'v2'});
+
+                await pdb.setSub('k', [], 'v3');
+                assert.equal(await pdb.get('k'), 'v3');
               });
 
               it('setSub can add a new property', async function () {
-                await pdb.set('k', {});
+                await pdb.remove('k');
+                await pdb.setSub('k', [], {});
+                assert.deepEqual(await pdb.get('k'), {});
                 await pdb.setSub('k', ['sub1'], {});
                 assert.deepEqual(await pdb.get('k'), {sub1: {}});
                 await pdb.setSub('k', ['sub1', 'sub2'], 'v');
                 assert.deepEqual(await pdb.get('k'), {sub1: {sub2: 'v'}});
+
+                await pdb.remove('k');
+                await pdb.setSub('k', ['sub1', 'sub2'], 'v');
+                assert.deepEqual(await pdb.get('k'), {sub1: {sub2: 'v'}});
+              });
+
+              it('setSub rejects attempts to set properties on primitives', async function () {
+                for (const v of ['hello world', 42, true]) {
+                  await pdb.set('k', v);
+                  assert.rejects(pdb.setSub('k', ['sub'], 'x'), {
+                    name: 'TypeError',
+                    message: /property "sub" on non-object/,
+                  });
+                  assert.deepEqual(await pdb.get('k'), v);
+                }
               });
 
               it('speed is acceptable', async function () {


### PR DESCRIPTION
Multiple commits:
* tests: Drop "Acceptable ms/op" column if there is no enforced limit
* tests: Move db promisification to a separate function
* tests: Factor out common promisification logic
* tests: Fix error handling in `promisifyBufferedFn()`
* tests: Add tests for `getSub()`, `setSub()`
* cache: Always call both of the callbacks (buffered and written)
* cache: Fix `setSub()` corner cases

None of the issues fixed in this PR are new, so this is unlikely to address #176 or ether/etherpad-lite#4645.