### PR TITLE
Fix setSub() failure to update records

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -206,7 +206,8 @@ exports.Database.prototype.get = function (key, callback) {
       this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
                         `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
     }
-    return callback(null, entry.value);
+    setImmediate(() => callback(null, entry.value));
+    return;
   }
   // get it direct
   this.wrappedDB.get(key, (err, value) => {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -277,11 +277,13 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
     // dirty must be set to true when the entry is passed to this.buffer.set() otherwise the
     // buffer might immediately evict the entry.
     entry = {value, dirty: true};
-    this.buffer.set(key, entry);
   } else if (entry.value !== value) {
     entry.value = value;
     entry.dirty = true;
   }
+  // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
+  // recently used.
+  this.buffer.set(key, entry);
   if (bufferCallback) setImmediate(bufferCallback);
   if (!entry.dirty) {
     if (writeCallback) setImmediate(writeCallback);

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -273,14 +273,9 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
   // the new value is written. (If the existing entry is updated instead, then the writeCallback for
   // the new value would be called when the old value is committed, not when the new value is
   // committed.)
-  if (!entry || (entry.writingInProgress && entry.value !== value)) {
-    // dirty must be set to true when the entry is passed to this.buffer.set() otherwise the
-    // buffer might immediately evict the entry.
-    entry = {value, dirty: true};
-  } else if (entry.value !== value) {
-    entry.value = value;
-    entry.dirty = true;
-  }
+  if (!entry || entry.writingInProgress) entry = {};
+  entry.value = value;
+  entry.dirty = true;
   // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
   // recently used.
   this.buffer.set(key, entry);


### PR DESCRIPTION
Multiple commits:
* cache: Always call the callback passed to `get()` asynchronously
* cache: Always mark the cache entry as most recently used in `set()`
* cache: Always assume that `set()` is called with a new value

Fixes #176.