### PR TITLE
redis: Fix "Callback was already called" error

### DIFF
--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -26,13 +26,13 @@ exports.Database = function (settings) {
 };
 
 exports.Database.prototype.auth = function (callback) {
-  if (this.settings.password) return this.client.auth(this.settings.password, callback);
-  callback();
+  if (!this.settings.password) return callback();
+  this.client.auth(this.settings.password, callback);
 };
 
 exports.Database.prototype.select = function (callback) {
-  if (this.settings.database) return this.client.select(this.settings.database, callback);
-  callback();
+  if (!this.settings.database) return callback();
+  this.client.select(this.settings.database, callback);
 };
 
 exports.Database.prototype.init = function (callback) {

--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -26,7 +26,7 @@ exports.Database = function (settings) {
 };
 
 exports.Database.prototype.auth = function (callback) {
-  if (this.settings.password) this.client.auth(this.settings.password, callback);
+  if (this.settings.password) return this.client.auth(this.settings.password, callback);
   callback();
 };
 


### PR DESCRIPTION
Multiple commits:
* redis: Add missing `return` in `auth()`
* redis: Invert condition in `auth()` and `select()` for readability

This should fix the exception that was reported in ether/etherpad-lite#4693.