### PR TITLE
dirty: Work around write-after-close bug in `dirty` package

### DIFF
--- a/databases/dirty_db.js
+++ b/databases/dirty_db.js
@@ -70,6 +70,9 @@ exports.Database.prototype.remove = function (key, callback) {
 };
 
 exports.Database.prototype.close = function (callback) {
-  this.db.close();
-  if (callback) callback();
+  // Sleep a bit before closing to work around https://github.com/ether/etherpad-lite/issues/4684.
+  setTimeout(() => {
+    this.db.close();
+    if (callback) callback();
+  }, 500);
 };


### PR DESCRIPTION
Addresses but is not a proper fix for https://github.com/ether/etherpad-lite/issues/4684.