### PR TITLE
cache: Asyncify part 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ exports.Database.prototype.doShutdown = function (callback) {
  * Writes any unsaved changes to the underlying database.
  */
 exports.Database.prototype.flush = function (callback) {
-  this.db.flush(callback);
+  util.callbackify(this.db.flush.bind(this.db))(callback);
 };
 
 exports.Database.prototype.get = function (key, callback) {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -34,6 +34,7 @@
  */
 
 const async = require('async');
+const util = require('util');
 
 /**
  * Cache with Least Recently Used eviction policy.
@@ -398,7 +399,7 @@ exports.Database.prototype.flush = function (callback = null) {
     return;
   }
   this.isFlushing = true;
-  this._write(dirtyEntries, (err) => {
+  util.callbackify(this._write.bind(this))(dirtyEntries, (err) => {
     this.isFlushing = false;
     if (err != null) return this._callFlushDoneCallbacks(err);
     // Recurse in case new dirty entries were created while writing these dirty entries. Once there
@@ -407,43 +408,8 @@ exports.Database.prototype.flush = function (callback = null) {
   });
 };
 
-exports.Database.prototype._write = function (dirtyEntries, callback = null) {
-  if (dirtyEntries.length === 0) {
-    if (callback) setImmediate(callback);
-    return;
-  }
-  const writtenCallback = (err) => {
-    for (const [, entry] of dirtyEntries) {
-      entry.writingInProgress = false;
-      // entry.callbacks must be set to [] before the callbacks are called to avoid a problematic
-      // corner case: If a callback called set() for the same key but a different value, the new
-      // callback passed to set() would be immediately added to entry.callbacks and called
-      // prematurely.
-      //
-      // An alternative approach that would also work: Call the callbacks via setImmediate(). This
-      // adds a bit of overhead, and it might make stack traces less useful.
-      //
-      // Another alternative: Set writingInProgress to false *after* calling the callbacks, not
-      // before. This would cause set() to generate a new dirty entry (and thus an independent
-      // callback list) for the key. There are some minor disadvantages to this approach:
-      //   * writingInProgress will be true while the callbacks are running even though the write
-      //     has completed. That could be confusing when debugging.
-      //   * If set() is called for the same key as this entry but with a different value, two
-      //     entries for the same key will briefly exist at the same time: One referenced here (in
-      //     the dirtyEntries list) and one saved in this.buffer.
-      //   * If set() is called for the same key as this entry and with the same value, the
-      //     callbacks list for this entry will be mutated during iteration. In general, it is
-      //     dangerous to mutate a container during iteration (doing so is a code smell).
-      const callbacks = entry.callbacks;
-      entry.callbacks = [];
-      for (const cb of callbacks) cb(err);
-    }
-    if (callback) callback();
-    // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
-    // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
-    // it should be safe to continue using the memory until the next call to this.buffer.set()
-    // evicts the old entries.
-  };
+exports.Database.prototype._write = async function (dirtyEntries) {
+  if (dirtyEntries.length === 0) return;
   const ops = dirtyEntries.map(([key, entry]) => {
     entry.dirty = false;
     entry.writingInProgress = true;
@@ -451,21 +417,55 @@ exports.Database.prototype._write = function (dirtyEntries, callback = null) {
       ? JSON.stringify(entry.value) : clone(entry.value);
     return {type: entry.value == null ? 'remove' : 'set', key, value};
   });
-  if (ops.length === 1) {
-    const {type, key, value} = ops[0];
-    switch (type) {
-      case 'remove':
-        this.wrappedDB.remove(key, writtenCallback);
-        break;
-      case 'set':
-        this.wrappedDB.set(key, value, writtenCallback);
-        break;
-      default:
-        throw new Error(`unsupported operation type: ${type}`);
+  let writeErr = null;
+  try {
+    if (ops.length === 1) {
+      const {type, key, value} = ops[0];
+      switch (type) {
+        case 'remove':
+          await util.promisify(this.wrappedDB.remove.bind(this.wrappedDB))(key);
+          break;
+        case 'set':
+          await util.promisify(this.wrappedDB.set.bind(this.wrappedDB))(key, value);
+          break;
+        default:
+          throw new Error(`unsupported operation type: ${type}`);
+      }
+    } else {
+      await util.promisify(this.wrappedDB.doBulk.bind(this.wrappedDB))(ops);
     }
-  } else {
-    this.wrappedDB.doBulk(ops, writtenCallback);
+  } catch (err) {
+    writeErr = err;
   }
+  for (const [, entry] of dirtyEntries) {
+    entry.writingInProgress = false;
+    // entry.callbacks must be set to [] before the callbacks are called to avoid a problematic
+    // corner case: If a callback called set() for the same key but a different value, the new
+    // callback passed to set() would be immediately added to entry.callbacks and called
+    // prematurely.
+    //
+    // An alternative approach that would also work: Call the callbacks via setImmediate(). This
+    // adds a bit of overhead, and it might make stack traces less useful.
+    //
+    // Another alternative: Set writingInProgress to false *after* calling the callbacks, not
+    // before. This would cause set() to generate a new dirty entry (and thus an independent
+    // callback list) for the key. There are some minor disadvantages to this approach:
+    //   * writingInProgress will be true while the callbacks are running even though the write
+    //     has completed. That could be confusing when debugging.
+    //   * If set() is called for the same key as this entry but with a different value, two
+    //     entries for the same key will briefly exist at the same time: One referenced here (in
+    //     the dirtyEntries list) and one saved in this.buffer.
+    //   * If set() is called for the same key as this entry and with the same value, the
+    //     callbacks list for this entry will be mutated during iteration. In general, it is
+    //     dangerous to mutate a container during iteration (doing so is a code smell).
+    const callbacks = entry.callbacks;
+    entry.callbacks = [];
+    for (const cb of callbacks) cb(writeErr);
+  }
+  // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
+  // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
+  // it should be safe to continue using the memory until the next call to this.buffer.set()
+  // evicts the old entries. This saves some CPU cycles at the expense of memory.
 };
 
 const clone = (obj) => {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -160,9 +160,6 @@ exports.Database = function (wrappedDB, settings, logger) {
   this.flushInterval = this.settings.writeInterval > 0
     ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
 
-  this.isFlushing = false;
-  this._flushDoneCallbacks = [];
-
   /**
    * Adds function to db wrapper for findKey regex.
    * Used by document dbs like mongodb or dirty.
@@ -191,7 +188,7 @@ exports.Database.prototype.init = function (callback) {
 */
 exports.Database.prototype.close = function (callback) {
   clearInterval(this.flushInterval);
-  this.flush((err) => {
+  util.callbackify(this.flush.bind(this))((err) => {
     if (err != null) return callback(err);
     this.wrappedDB.close(callback);
   });
@@ -378,34 +375,24 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
   });
 };
 
-exports.Database.prototype._callFlushDoneCallbacks = function (err) {
-  const callbacks = this._flushDoneCallbacks;
-  this._flushDoneCallbacks = []; // In case a callback calls flush().
-  for (const cb of callbacks) cb(err);
-};
-
 /**
  Writes all dirty values to the database
 */
-exports.Database.prototype.flush = function (callback = null) {
-  if (callback) this._flushDoneCallbacks.push(callback);
-  if (this.isFlushing) return;
-  const dirtyEntries = [];
-  for (const entry of this.buffer) {
-    if (entry[1].dirty) dirtyEntries.push(entry);
+exports.Database.prototype.flush = async function () {
+  if (this._flushDone == null) {
+    this._flushDone = (async () => {
+      for (;;) {
+        const dirtyEntries = [];
+        for (const entry of this.buffer) {
+          if (entry[1].dirty) dirtyEntries.push(entry);
+        }
+        if (dirtyEntries.length === 0) return;
+        await this._write(dirtyEntries);
+      }
+    })();
   }
-  if (dirtyEntries.length === 0) {
-    setImmediate(() => this._callFlushDoneCallbacks());
-    return;
-  }
-  this.isFlushing = true;
-  util.callbackify(this._write.bind(this))(dirtyEntries, (err) => {
-    this.isFlushing = false;
-    if (err != null) return this._callFlushDoneCallbacks(err);
-    // Recurse in case new dirty entries were created while writing these dirty entries. Once there
-    // are no more dirty entries, the base case above will trigger.
-    this.flush();
-  });
+  await this._flushDone;
+  this._flushDone = null;
 };
 
 exports.Database.prototype._write = async function (dirtyEntries) {


### PR DESCRIPTION
First in a series to modernize ueberDB:
* cache: Asyncify `_write()`
* cache: Asyncify `flush()`