### PR TITLE
redis: Fix initialization with new settings object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Notable Changes
 
+## v1.2.9
+
+* `dirty`: Workaround for a bug in the upstream `dirty` driver.
+
+## v1.2.7
+
+* `redis`: Experimental support for passing the settings object directly to the
+  `redis` package.
+
+## v1.2.6
+
+* `redis`: Fixed "Callback was already called" exception during init.
+
+## v1.2.5
+
+* All: Fixed a major bug introduced in v1.1.10 that caused `setSub()` to
+  silently discard changes.
+* All: Fixed a bug that prevented cache entries from being marked as most
+  recently used.
+
+## v1.2.4
+
+* `mssql`: Updated `mssql` dependency.
+* `dirty_git`: Updated `simple-git` dependency.
+* `sqlite`: Updated `sqlite3` dependency.
+
+## v1.2.3
+
+* `mssql`: Updated `mssql` dependency.
+
+## v1.2.2
+
+* All: Fixed minor `setSub()` corner cases.
+
 ## v1.2.1
 
 * New `flush()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Notable Changes
 
+## v1.3.1
+
+* `redis`: The database config object is now passed directly to the `redis`
+  package. For details, see
+  https://www.npmjs.com/package/redis/v/3.0.2#options-object-properties.
+  Old-style settings objects (where the `redis` options are in the
+  `client_options` property) are still supported but deprecated.
+
 ## v1.2.9
 
 * `dirty`: Workaround for a bug in the upstream `dirty` driver.

--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -35,22 +35,25 @@ exports.Database.prototype.select = function (callback) {
   this.client.select(this.settings.database, callback);
 };
 
-exports.Database.prototype.init = function (callback) {
+exports.Database.prototype._deprecatedInit = function (callback) {
   if (this.settings.socket) {
     // Deprecated, but kept for backwards compatibility.
     this.client = redis.createClient(this.settings.socket,
         this.settings.client_options);
-  } else if (this.settings.client_options) {
+  } else {
     // Deprecated, but kept for backwards compatibility.
     this.client = redis.createClient(this.settings.port,
         this.settings.host, this.settings.client_options);
-  } else {
-    // This is the preferred way to configure the client.
-    this.client = redis.createClient(this.settings);
   }
 
   this.client.database = this.settings.database;
   async.waterfall([this.auth.bind(this), this.select.bind(this)], callback);
+};
+
+exports.Database.prototype.init = function (callback) {
+  if (this.settings.socket || this.settings.client_options) return this._deprecatedInit(callback);
+  this.client = redis.createClient(this.settings);
+  callback();
 };
 
 exports.Database.prototype.get = function (key, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ueberdb2",
-  "version": "1.2.12",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "url": "https://github.com/ether/ueberDB.git"
   },
   "main": "./index",
-  "version": "1.2.12",
+  "version": "1.3.0",
   "bugs": {
     "url": "https://github.com/ether/ueberDB/issues"
   },

--- a/test/lib/databases.js
+++ b/test/lib/databases.js
@@ -36,7 +36,6 @@ exports.databases = {
     charset: 'utf8mb4',
   },
   redis: {
-    hostname: '127.0.0.1',
   },
   mongodb: {
     url: 'mongodb://127.0.0.1:27017',


### PR DESCRIPTION
Multiple commits:
* docs: Update `CHANGELOG.md`
* redis: Don't call `auth()` or `select()` with new config object
* redis tests: Delete ignored `hostname` setting
* Bump minor version for `redis` API change
