### PR TITLE
cache: Asyncify part 2: Use a Promise to manage write callbacks

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -273,6 +273,9 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
   // committed.)
   if (!entry || entry.writingInProgress) entry = {};
   entry.value = value;
+  // Always mark as dirty even if the value did not change. This simplifies the implementation: this
+  // function doesn't need to perform deep comparisons, and setSub() doesn't need to perform a deep
+  // copy of the object returned from get().
   entry.dirty = true;
   // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
   // recently used.

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -154,6 +154,14 @@ exports.Database = function (wrappedDB, settings, logger) {
   // freeze the settings at this point
   this.settings = Object.freeze(this.settings);
 
+  // The key is the database key. The value is an object with the following properties:
+  //   - value: The entry's value.
+  //   - dirty: Boolean indicating whether the value has been written to the underlying database or
+  //     not.
+  //   - callbacks: List of Node-style callbacks that will be called once the value has been written
+  //     to the underlying database.
+  //   - writingInProgress: Boolean that if true indicates that the value has been sent to the
+  //     underlying database and we are awaiting commit.
   this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
 
   // start the write Interval

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -281,10 +281,6 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
   // recently used.
   this.buffer.set(key, entry);
   if (bufferCallback) setImmediate(bufferCallback);
-  if (!entry.dirty) {
-    if (writeCallback) setImmediate(writeCallback);
-    return;
-  }
   if (!entry.callbacks) entry.callbacks = [];
   entry.callbacks.push(writeCallback || ((err) => { if (err != null) throw err; }));
   const buffered = this.settings.writeInterval > 0;

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -383,7 +383,7 @@ exports.Database.prototype.flush = async function () {
       while (true) {
         const dirtyEntries = [];
         for (const entry of this.buffer) {
-          if (entry[1].dirty) dirtyEntries.push(entry);
+          if (entry[1].dirty && !entry[1].writingInProgress) dirtyEntries.push(entry);
         }
         if (dirtyEntries.length === 0) return;
         await this._write(dirtyEntries);
@@ -397,7 +397,6 @@ exports.Database.prototype.flush = async function () {
 exports.Database.prototype._write = async function (dirtyEntries) {
   if (dirtyEntries.length === 0) return;
   const ops = dirtyEntries.map(([key, entry]) => {
-    entry.dirty = false;
     entry.writingInProgress = true;
     const value = this.settings.json && entry.value != null
       ? JSON.stringify(entry.value) : clone(entry.value);
@@ -425,6 +424,9 @@ exports.Database.prototype._write = async function (dirtyEntries) {
   }
   for (const [, entry] of dirtyEntries) {
     entry.writingInProgress = false;
+    // If writeErr != null then the entry is stil technically dirty, but the responsibility is on
+    // the user to retry failures so from ueberDB's perspective the entry is no longer dirty.
+    entry.dirty = false;
     // entry.callbacks must be set to [] before the callbacks are called to avoid a problematic
     // corner case: If a callback called set() for the same key but a different value, the new
     // callback passed to set() would be immediately added to entry.callbacks and called

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -103,6 +103,19 @@ class LRU {
   }
 }
 
+// Same as Promise but with a `done` property set to a Node-style callback that resolves/rejects the
+// Promise.
+class SelfContainedPromise extends Promise {
+  constructor(executor = null) {
+    let done;
+    super((resolve, reject) => {
+      done = (err, val) => err != null ? reject(err) : resolve(val);
+      if (executor != null) executor(resolve, reject);
+    });
+    this.done = done;
+  }
+}
+
 const defaultSettings =
 {
   // the number of elements that should be cached. To Disable cache just set it to zero
@@ -156,10 +169,8 @@ exports.Database = function (wrappedDB, settings, logger) {
 
   // The key is the database key. The value is an object with the following properties:
   //   - value: The entry's value.
-  //   - dirty: Boolean indicating whether the value has been written to the underlying database or
-  //     not.
-  //   - callbacks: List of Node-style callbacks that will be called once the value has been written
-  //     to the underlying database.
+  //   - dirty: If the value has not yet been written, this is a Promise that will resolve once the
+  //     write to the underlying database returns. If the value has been written this is null.
   //   - writingInProgress: Boolean that if true indicates that the value has been sent to the
   //     underlying database and we are awaiting commit.
   this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
@@ -232,7 +243,7 @@ exports.Database.prototype.get = function (key, callback) {
     if (this.settings.cache > 0) {
       this.buffer.set(key, {
         value,
-        dirty: false,
+        dirty: null,
         writingInProgress: false,
       });
     }
@@ -284,13 +295,14 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
   // Always mark as dirty even if the value did not change. This simplifies the implementation: this
   // function doesn't need to perform deep comparisons, and setSub() doesn't need to perform a deep
   // copy of the object returned from get().
-  entry.dirty = true;
+  if (!entry.dirty) entry.dirty = new SelfContainedPromise();
   // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
   // recently used.
   this.buffer.set(key, entry);
   if (bufferCallback) setImmediate(bufferCallback);
-  if (!entry.callbacks) entry.callbacks = [];
-  entry.callbacks.push(writeCallback || ((err) => { if (err != null) throw err; }));
+  if (writeCallback) {
+    entry.dirty.then(() => writeCallback(), (err) => writeCallback(err || new Error(err)));
+  }
   const buffered = this.settings.writeInterval > 0;
   if (this.logger.isDebugEnabled()) {
     this.logger.debug(
@@ -428,35 +440,14 @@ exports.Database.prototype._write = async function (dirtyEntries) {
       await util.promisify(this.wrappedDB.doBulk.bind(this.wrappedDB))(ops);
     }
   } catch (err) {
-    writeErr = err;
+    writeErr = err || new Error(err);
   }
   for (const [, entry] of dirtyEntries) {
     entry.writingInProgress = false;
+    entry.dirty.done(writeErr);
     // If writeErr != null then the entry is stil technically dirty, but the responsibility is on
     // the user to retry failures so from ueberDB's perspective the entry is no longer dirty.
-    entry.dirty = false;
-    // entry.callbacks must be set to [] before the callbacks are called to avoid a problematic
-    // corner case: If a callback called set() for the same key but a different value, the new
-    // callback passed to set() would be immediately added to entry.callbacks and called
-    // prematurely.
-    //
-    // An alternative approach that would also work: Call the callbacks via setImmediate(). This
-    // adds a bit of overhead, and it might make stack traces less useful.
-    //
-    // Another alternative: Set writingInProgress to false *after* calling the callbacks, not
-    // before. This would cause set() to generate a new dirty entry (and thus an independent
-    // callback list) for the key. There are some minor disadvantages to this approach:
-    //   * writingInProgress will be true while the callbacks are running even though the write
-    //     has completed. That could be confusing when debugging.
-    //   * If set() is called for the same key as this entry but with a different value, two
-    //     entries for the same key will briefly exist at the same time: One referenced here (in
-    //     the dirtyEntries list) and one saved in this.buffer.
-    //   * If set() is called for the same key as this entry and with the same value, the
-    //     callbacks list for this entry will be mutated during iteration. In general, it is
-    //     dangerous to mutate a container during iteration (doing so is a code smell).
-    const callbacks = entry.callbacks;
-    entry.callbacks = [];
-    for (const cb of callbacks) cb(writeErr);
+    entry.dirty = null;
   }
   // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
   // this.buffer is at or below capacity, but if we haven't run out of memory by this point then


### PR DESCRIPTION
Multiple commits:
* cache: Add a comment explaining why `set()` always marks dirty
* cache: Delete unnecessary `if` condition
* cache: Set `entry.dirty = false` after write (for readability)
* cache: Document the properties of a cache entry
* cache: Use a Promise instead of a list of callbacks
