### PR TITLE
cache: Promisify part 4: Modernize locking

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ exports.Database.prototype.get = function (key, callback) {
 };
 
 exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  this.channels.emit(key, {db: this.db, type: 'findKeys', key, notKey, callback});
+  util.callbackify(this.db.findKeys.bind(this.db))(key, notKey, (e, v) => callback(e, clone(v)));
 };
 
 exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
@@ -137,17 +137,6 @@ const doOperation = (operation, callback) => {
       // call the caller callback
       if (operation.bufferCallback) operation.bufferCallback(err);
     }, operation.writeCallback);
-  } else if (operation.type === 'findKeys') {
-    util.callbackify(db.findKeys.bind(db))(operation.key, operation.notKey, (err, value) => {
-      // clone the value
-      value = clone(value);
-
-      // call the caller callback
-      operation.callback(err, value);
-
-      // call the queue callback
-      callback();
-    });
   } else if (operation.type === 'set') {
     db.set(operation.key, operation.value, (err) => {
       // call the queue callback

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -175,6 +175,9 @@ exports.Database = function (wrappedDB, settings, logger) {
   //     underlying database and we are awaiting commit.
   this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
 
+  // Maps database key to a Promise that is resolved when the record is unlocked.
+  this._locks = new Map();
+
   // start the write Interval
   this.flushInterval = this.settings.writeInterval > 0
     ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
@@ -193,6 +196,20 @@ exports.Database = function (wrappedDB, settings, logger) {
     }
     return new RegExp(regex);
   };
+};
+
+exports.Database.prototype._lock = async function (key) {
+  while (true) {
+    const l = this._locks.get(key);
+    if (l == null) break;
+    await l;
+  }
+  this._locks.set(key, new SelfContainedPromise());
+};
+
+exports.Database.prototype._unlock = async function (key) {
+  this._locks.get(key).done();
+  this._locks.delete(key);
 };
 
 /**
@@ -216,6 +233,15 @@ exports.Database.prototype.close = async function () {
  Gets the value trough the wrapper.
 */
 exports.Database.prototype.get = async function (key) {
+  await this._lock(key);
+  try {
+    return await this._getLocked(key);
+  } finally {
+    this._unlock(key);
+  }
+};
+
+exports.Database.prototype._getLocked = async function (key) {
   const entry = this.buffer.get(key);
   if (entry != null) {
     if (this.logger.isDebugEnabled()) {
@@ -277,6 +303,11 @@ exports.Database.prototype.remove = function (key, bufferCallback, writeCallback
  Sets the value trough the wrapper
 */
 exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
+  const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
+  this._lock(key).then(() => this._setLocked(key, value, bcb, writeCallback));
+};
+
+exports.Database.prototype._setLocked = function (key, value, bufferCallback, writeCallback) {
   let entry = this.buffer.get(key);
   // If there is a write of a different value for the same key already in progress then don't update
   // the existing entry object -- create a new entry object instead and replace the old one in
@@ -316,10 +347,9 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
   }
 
   async.waterfall([
+    util.callbackify(this._lock.bind(this, key)),
     // get the full value
-    (callback) => {
-      util.callbackify(this.get.bind(this))(key, callback);
-    },
+    util.callbackify(this._getLocked.bind(this, key)),
     // set the sub value and set the full value again
     (fullValue, callback) => {
       const base = {fullValue};
@@ -342,11 +372,13 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
         ptr.prop = sub[i];
       }
       ptr.obj[ptr.prop] = value;
-      this.set(key, base.fullValue, bufferCallback, writeCallback);
+      const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
+      this._setLocked(key, base.fullValue, bcb, writeCallback);
       callback(null);
     },
   ], (err) => {
     if (err) {
+      this._unlock(key);
       if (bufferCallback) bufferCallback(err);
       if (writeCallback) writeCallback(err);
       if (!bufferCallback && !writeCallback) throw err;
@@ -360,27 +392,32 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
  *     "bla"]
  */
 exports.Database.prototype.getSub = async function (key, sub) {
-  // get the full value
-  const value = await this.get(key);
+  await this._lock(key);
+  try {
+    // get the full value
+    const value = await this._getLocked(key);
 
-  // everything is correct, navigate to the subvalue and return it
-  let subvalue = value;
+    // everything is correct, navigate to the subvalue and return it
+    let subvalue = value;
 
-  for (let i = 0; i < sub.length; i++) {
-    // test if the subvalue exist
-    if (subvalue != null && subvalue[sub[i]] !== undefined) {
-      subvalue = subvalue[sub[i]];
-    } else {
-      // the subvalue doesn't exist, break the loop and return null
-      subvalue = null;
-      break;
+    for (let i = 0; i < sub.length; i++) {
+      // test if the subvalue exist
+      if (subvalue != null && subvalue[sub[i]] !== undefined) {
+        subvalue = subvalue[sub[i]];
+      } else {
+        // the subvalue doesn't exist, break the loop and return null
+        subvalue = null;
+        break;
+      }
     }
-  }
 
-  if (this.logger.isDebugEnabled()) {
-    this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+    }
+    return subvalue;
+  } finally {
+    this._unlock(key);
   }
-  return subvalue;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,11 +509,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "channels": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/channels/-/channels-0.0.4.tgz",
-      "integrity": "sha1-G+4yPt6hUrue8E9BvG5rD1lIqUE="
-    },
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "async": "^3.2.0",
     "cassandra-driver": "^4.5.1",
-    "channels": "0.0.4",
     "dirty": "^1.1.1",
     "elasticsearch": "^16.7.1",
     "mongodb": "^3.6.3",


### PR DESCRIPTION
Multiple commits:
* Remove useless locking around `findKeys()`
* Move locking into cache, convert to Promises
* Expose a metric for lock contention

This is marked as draft because it depends on PR #193. Once that PR is merged this can be rebased and marked as ready for review.