### PR TITLE
cache: Promisify part 5: Write methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Notable Changes
 
+## v1.4.1
+
+* The two callback arguments in `remove()`, `set()`, and `setSub()` have
+  changed: Instead of a callback that is called after the write is buffered and
+  another callback that is called after the write is committed, both callbacks
+  are now called after the write is committed. Futhermore, the second callback
+  argument is now deprecated.
+
 ## v1.3.2
 
 * `dirty`: Updated `dirty` dependency.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ async function example(db){
 
 example(db);
 ```
+
 ### Getting and setting subkeys
 
 ueberDB can store complex JSON objects. Sometimes you only want to get or set a
@@ -146,7 +147,7 @@ db.set(key, {prop1: {prop2: ['value']}}, (err) => {
 #### `setSub`
 
 ```javascript
-db.setSub(key, propertyPath, value, bufferedCallback, writtenCallback);
+db.setSub(key, propertyPath, value, cb);
 ```
 
 Fetches the object stored at `key`, walks the property path given in
@@ -154,10 +155,8 @@ Fetches the object stored at `key`, walks the property path given in
 must be an array. If `propertyPath` is an empty array then `setSub()` is
 equivalent to `set()`. Empty objects are created as needed if the property path
 does not exist (including if `key` does not exist in the database). It is an
-error to attempt to set a property on a non-object. `bufferedCallback` is
-optional and is called when the change has been buffered. `writtenCallback` is
-optional and is called when the database driver has reported that the change has
-been written.
+error to attempt to set a property on a non-object. `cb` is optional and is
+called when the database driver has reported that the change has been written.
 
 Examples:
 

--- a/databases/mock_db.js
+++ b/databases/mock_db.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const events = require('events');
+
+exports.Database = class extends events.EventEmitter {
+  constructor(settings) {
+    super();
+    this.settings = settings;
+    settings.mock = this;
+  }
+
+  close(cb) {
+    this.emit('close', cb);
+  }
+
+  doBulk(ops, cb) {
+    this.emit('doBulk', ops, cb);
+  }
+
+  findKeys(key, notKey, cb) {
+    this.emit('findKeys', key, notKey, cb);
+  }
+
+  get(key, cb) {
+    this.emit('get', key, cb);
+  }
+
+  init(cb) {
+    this.emit('init', cb);
+  }
+
+  remove(key, cb) {
+    this.emit('remove', key, cb);
+  }
+
+  set(key, value, cb) {
+    this.emit('set', key, value, cb);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -101,20 +101,44 @@ exports.Database.prototype.findKeys = function (key, notKey, callback) {
   util.callbackify(this.db.findKeys.bind(this.db))(key, notKey, (e, v) => callback(e, clone(v)));
 };
 
-exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
-  this.db.remove(key, bufferCallback, writeCallback);
+const makeDoneCallback = (callback, deprecated) => (err) => {
+  if (callback) callback(err);
+  if (deprecated) deprecated(err);
+  if (err != null && callback == null && deprecated == null) throw err;
 };
 
-exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
-  this.db.set(key, clone(value), bufferCallback, writeCallback);
+/**
+ * Removes an entry from the database if present.
+ *
+ * @param cb Called when the write has been committed to the underlying database driver.
+ * @param deprecated Deprecated callback that is called just after cb.
+ */
+exports.Database.prototype.remove = function (key, cb, deprecated = null) {
+  this.db.remove(key, makeDoneCallback(cb, deprecated));
+};
+
+/**
+ * Adds or changes the value of an entry.
+ *
+ * @param cb Called when the write has been committed to the underlying database driver.
+ * @param deprecated Deprecated callback that is called just after cb.
+ */
+exports.Database.prototype.set = function (key, value, cb, deprecated = null) {
+  this.db.set(key, clone(value), makeDoneCallback(cb, deprecated));
 };
 
 exports.Database.prototype.getSub = function (key, sub, callback) {
   util.callbackify(this.db.getSub.bind(this.db))(key, sub, (err, val) => callback(err, clone(val)));
 };
 
-exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
-  this.db.setSub(key, sub, clone(value), bufferCallback, writeCallback);
+/**
+ * Adds or changes a subvalue of an entry.
+ *
+ * @param cb Called when the write has been committed to the underlying database driver.
+ * @param deprecated Deprecated callback that is called just after cb.
+ */
+exports.Database.prototype.setSub = function (key, sub, value, cb, deprecated = null) {
+  this.db.setSub(key, sub, clone(value), makeDoneCallback(cb, deprecated));
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ exports.Database.prototype.getSub = function (key, sub, callback) {
  * @param deprecated Deprecated callback that is called just after cb.
  */
 exports.Database.prototype.setSub = function (key, sub, value, cb, deprecated = null) {
-  this.db.setSub(key, sub, clone(value), makeDoneCallback(cb, deprecated));
+  util.callbackify(this.db.setSub.bind(this.db))(
+      key, sub, clone(value), makeDoneCallback(cb, deprecated));
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -57,11 +57,17 @@ exports.Database = function (type, dbSettings, wrapperSettings, logger = null) {
   this.dbSettings = dbSettings;
   this.wrapperSettings = wrapperSettings;
   this.logger = normalizeLogger(logger);
+  const db = new this.dbModule.Database(this.dbSettings);
+  this.db = new cacheAndBufferLayer.Database(db, this.wrapperSettings, this.logger);
+
+  // Expose the cache wrapper's metrics to the user. See lib/CacheAndBufferLayer.js for details.
+  //
+  // WARNING: This feature is EXPERIMENTAL -- do not assume it will continue to exist in its current
+  // form in a future version.
+  this.metrics = this.db.metrics;
 };
 
 exports.Database.prototype.init = function (callback) {
-  const db = new this.dbModule.Database(this.dbSettings);
-  this.db = new cacheAndBufferLayer.Database(db, this.wrapperSettings, this.logger);
   if (callback) {
     util.callbackify(this.db.init.bind(this.db))(callback);
   } else {

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ const makeDoneCallback = (callback, deprecated) => (err) => {
  * @param deprecated Deprecated callback that is called just after cb.
  */
 exports.Database.prototype.remove = function (key, cb, deprecated = null) {
-  this.db.remove(key, makeDoneCallback(cb, deprecated));
+  util.callbackify(this.db.remove.bind(this.db))(key, makeDoneCallback(cb, deprecated));
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ exports.Database.prototype.get = function (key, callback) {
 };
 
 exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  this.channels.emit(key, {db: this.db, type: 'findKeys', key, notKey, callback});
+  util.callbackify(this.db.findKeys.bind(this.db))(key, notKey, (e, v) => callback(e, clone(v)));
 };
 
 exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
@@ -137,17 +137,6 @@ const doOperation = (operation, callback) => {
       // call the caller callback
       if (operation.bufferCallback) operation.bufferCallback(err);
     }, operation.writeCallback);
-  } else if (operation.type === 'findKeys') {
-    util.callbackify(db.findKeys.bind(db))(operation.key, operation.notKey, (err, value) => {
-      // clone the value
-      value = clone(value);
-
-      // call the caller callback
-      operation.callback(err, value);
-
-      // call the queue callback
-      callback();
-    });
   } else if (operation.type === 'set') {
     db.set(operation.key, operation.value, (err) => {
       // call the queue callback

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ exports.Database.prototype.remove = function (key, cb, deprecated = null) {
  * @param deprecated Deprecated callback that is called just after cb.
  */
 exports.Database.prototype.set = function (key, value, cb, deprecated = null) {
-  this.db.set(key, clone(value), makeDoneCallback(cb, deprecated));
+  util.callbackify(this.db.set.bind(this.db))(key, clone(value), makeDoneCallback(cb, deprecated));
 };
 
 exports.Database.prototype.getSub = function (key, sub, callback) {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -178,6 +178,40 @@ exports.Database = function (wrappedDB, settings, logger) {
   // Maps database key to a Promise that is resolved when the record is unlocked.
   this._locks = new Map();
 
+  this.metrics = {
+    // The number of times a database operation had to wait for the release of a record lock.
+    lockAwaits: 0,
+    // The number of times a record was locked.
+    lockAcquires: 0,
+    // The number of times a record was unlocked.
+    lockReleases: 0,
+    // Number of times `get()`, `getSub()`, and `setSub()` were called.
+    reads: 0,
+    // Number of times a value could not be fetched. This includes JSON parsing errors.
+    readsFailed: 0,
+    // Number of successfully completed or failed value reads. This minus `reads` is the number of
+    // in-progress reads. This minus `readsFromCache` is the number of reads that hit the database.
+    readsFinished: 0,
+    // Number of reads that were satisfied from in-memory state (including the write buffer).
+    readsFromCache: 0,
+    // Incremented each time `remove()`, `set()`, or `setSub()` is called, regardless of whether the
+    // value actually changed. The number of pending write operations is equal to this minus the sum
+    // of `writesFinished` and `writesObsoleted`.
+    writes: 0,
+    // The number of times the underlying database failed to write a value (including failed
+    // deletes).
+    writesFailed: 0,
+    // The number of times the underlying database either successfully completed or failed a write
+    // of a value (including record deletes).
+    writesFinished: 0,
+    // The number of times a pending but not yet started write operation was canceled because a call
+    // to `remove()`, `set()`, or `setSub()` rendered the write unnecessary.
+    writesObsoleted: 0,
+    // The number of times a value was sent to the underlying database (including record deletes).
+    // The number of in-progress writes is equal to this minus `writesFinished`.
+    writesStarted: 0,
+  };
+
   // start the write Interval
   this.flushInterval = this.settings.writeInterval > 0
     ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
@@ -202,12 +236,15 @@ exports.Database.prototype._lock = async function (key) {
   while (true) {
     const l = this._locks.get(key);
     if (l == null) break;
+    ++this.metrics.lockAwaits;
     await l;
   }
+  ++this.metrics.lockAcquires;
   this._locks.set(key, new SelfContainedPromise());
 };
 
 exports.Database.prototype._unlock = async function (key) {
+  ++this.metrics.lockReleases;
   this._locks.get(key).done();
   this._locks.delete(key);
 };
@@ -242,8 +279,11 @@ exports.Database.prototype.get = async function (key) {
 };
 
 exports.Database.prototype._getLocked = async function (key) {
+  ++this.metrics.reads;
   const entry = this.buffer.get(key);
   if (entry != null) {
+    ++this.metrics.readsFromCache;
+    ++this.metrics.readsFinished;
     if (this.logger.isDebugEnabled()) {
       this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
                         `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
@@ -252,14 +292,22 @@ exports.Database.prototype._getLocked = async function (key) {
   }
 
   // get it direct
-  let value = await util.promisify(this.wrappedDB.get.bind(this.wrappedDB))(key);
-  if (this.settings.json) {
-    try {
-      value = JSON.parse(value);
-    } catch (err) {
-      console.error(`JSON-PROBLEM:${value}`);
-      throw err;
+  let value;
+  try {
+    value = await util.promisify(this.wrappedDB.get.bind(this.wrappedDB))(key);
+    if (this.settings.json) {
+      try {
+        value = JSON.parse(value);
+      } catch (err) {
+        console.error(`JSON-PROBLEM:${value}`);
+        throw err;
+      }
     }
+  } catch (err) {
+    ++this.metrics.readsFailed;
+    throw err;
+  } finally {
+    ++this.metrics.readsFinished;
   }
 
   // cache the value if caching is enabled
@@ -308,6 +356,7 @@ exports.Database.prototype.set = function (key, value, bufferCallback, writeCall
 };
 
 exports.Database.prototype._setLocked = function (key, value, bufferCallback, writeCallback) {
+  ++this.metrics.writes;
   let entry = this.buffer.get(key);
   // If there is a write of a different value for the same key already in progress then don't update
   // the existing entry object -- create a new entry object instead and replace the old one in
@@ -316,6 +365,7 @@ exports.Database.prototype._setLocked = function (key, value, bufferCallback, wr
   // the new value would be called when the old value is committed, not when the new value is
   // committed.)
   if (!entry || entry.writingInProgress) entry = {};
+  else if (entry.dirty) ++this.metrics.writesObsoleted;
   entry.value = value;
   // Always mark as dirty even if the value did not change. This simplifies the implementation: this
   // function doesn't need to perform deep comparisons, and setSub() doesn't need to perform a deep
@@ -448,6 +498,7 @@ exports.Database.prototype._write = async function (dirtyEntries) {
       ? JSON.stringify(entry.value) : clone(entry.value);
     return {type: entry.value == null ? 'remove' : 'set', key, value};
   });
+  this.metrics.writesStarted += ops.length;
   let writeErr = null;
   try {
     if (ops.length === 1) {
@@ -467,7 +518,9 @@ exports.Database.prototype._write = async function (dirtyEntries) {
     }
   } catch (err) {
     writeErr = err || new Error(err);
+    this.metrics.writesFailed += ops.length;
   }
+  this.metrics.writesFinished += ops.length;
   for (const [, entry] of dirtyEntries) {
     entry.writingInProgress = false;
     entry.dirty.done(writeErr);

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -134,11 +134,17 @@ const defaultSettings =
  @param settings (optional) The settings that should be applied to the wrapper
 */
 exports.Database = function (wrappedDB, settings, logger) {
-  this.wrappedDB = {};
-  for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
-    const f = wrappedDB[fn];
-    if (typeof f !== 'function') continue;
-    this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
+  // wrappedDB.isAsync is a temporary boolean that will go away once we have migrated all of the
+  // database drivers from callback-based methods to async methods.
+  if (wrappedDB.isAsync) {
+    this.wrappedDB = wrappedDB;
+  } else {
+    this.wrappedDB = {};
+    for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
+      const f = wrappedDB[fn];
+      if (typeof f !== 'function') continue;
+      this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
+    }
   }
   this.logger = logger;
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -134,8 +134,12 @@ const defaultSettings =
  @param settings (optional) The settings that should be applied to the wrapper
 */
 exports.Database = function (wrappedDB, settings, logger) {
-  // saved the wrappedDB
-  this.wrappedDB = wrappedDB;
+  this.wrappedDB = {};
+  for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
+    const f = wrappedDB[fn];
+    if (typeof f !== 'function') continue;
+    this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
+  }
   this.logger = logger;
 
   // apply default settings
@@ -252,7 +256,7 @@ exports.Database.prototype._unlock = async function (key) {
  wraps the init function of the original DB
 */
 exports.Database.prototype.init = async function () {
-  await util.promisify(this.wrappedDB.init.bind(this.wrappedDB))();
+  await this.wrappedDB.init();
 };
 
 /**
@@ -261,7 +265,7 @@ exports.Database.prototype.init = async function () {
 exports.Database.prototype.close = async function () {
   clearInterval(this.flushInterval);
   await this.flush();
-  await util.promisify(this.wrappedDB.close.bind(this.wrappedDB))();
+  await this.wrappedDB.close();
   this.wrappedDB = null;
 };
 
@@ -293,7 +297,7 @@ exports.Database.prototype._getLocked = async function (key) {
   // get it direct
   let value;
   try {
-    value = await util.promisify(this.wrappedDB.get.bind(this.wrappedDB))(key);
+    value = await this.wrappedDB.get(key);
     if (this.settings.json) {
       try {
         value = JSON.parse(value);
@@ -331,7 +335,7 @@ exports.Database.prototype._getLocked = async function (key) {
  */
 exports.Database.prototype.findKeys = async function (key, notKey) {
   const bufferKey = `${key}-${notKey}`;
-  const keyValues = await util.promisify(this.wrappedDB.findKeys.bind(this.wrappedDB))(key, notKey);
+  const keyValues = await this.wrappedDB.findKeys(key, notKey);
   if (this.logger.isDebugEnabled()) {
     this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
   }
@@ -499,16 +503,16 @@ exports.Database.prototype._write = async function (dirtyEntries) {
       const {type, key, value} = ops[0];
       switch (type) {
         case 'remove':
-          await util.promisify(this.wrappedDB.remove.bind(this.wrappedDB))(key);
+          await this.wrappedDB.remove(key);
           break;
         case 'set':
-          await util.promisify(this.wrappedDB.set.bind(this.wrappedDB))(key, value);
+          await this.wrappedDB.set(key, value);
           break;
         default:
           throw new Error(`unsupported operation type: ${type}`);
       }
     } else {
-      await util.promisify(this.wrappedDB.doBulk.bind(this.wrappedDB))(ops);
+      await this.wrappedDB.doBulk(ops);
     }
   } catch (err) {
     writeErr = err || new Error(err);

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -33,7 +33,6 @@
  * overwriden by the driver and by the module user.
  */
 
-const async = require('async');
 const util = require('util');
 
 /**
@@ -395,42 +394,38 @@ exports.Database.prototype._setLocked = async function (key, value) {
 /**
  Sets a subvalue
 */
-exports.Database.prototype.setSub = function (key, sub, value, callback) {
+exports.Database.prototype.setSub = async function (key, sub, value) {
   if (this.logger.isDebugEnabled()) {
     this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
   }
-
-  async.waterfall([
-    util.callbackify(this._lock.bind(this, key)),
-    // get the full value
-    util.callbackify(this._getLocked.bind(this, key)),
-    // set the sub value and set the full value again
-    (fullValue, callback) => {
-      const base = {fullValue};
-      // Emulate a pointer to the property that should be set to `value`.
-      const ptr = {obj: base, prop: 'fullValue'};
-      for (let i = 0; i < sub.length; i++) {
-        let o = ptr.obj[ptr.prop];
-        if (o == null) ptr.obj[ptr.prop] = o = {};
-        // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
-        // ECMAScript automatically wraps primitives in a temporary wrapper object.
-        if (typeof o !== 'object') {
-          this._unlock(key);
-          callback(new TypeError(
-              `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
+  let p;
+  await this._lock(key);
+  try {
+    const fullValue = await this._getLocked(key);
+    const base = {fullValue};
+    // Emulate a pointer to the property that should be set to `value`.
+    const ptr = {obj: base, prop: 'fullValue'};
+    for (let i = 0; i < sub.length; i++) {
+      let o = ptr.obj[ptr.prop];
+      if (o == null) ptr.obj[ptr.prop] = o = {};
+      // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
+      // ECMAScript automatically wraps primitives in a temporary wrapper object.
+      if (typeof o !== 'object') {
+        throw new TypeError(
+            `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
               `(key: ${JSON.stringify(key)} ` +
               `value in db: ${JSON.stringify(fullValue)} ` +
-              `sub: ${JSON.stringify(sub.slice(0, i + 1))})`));
-          return;
-        }
-        ptr.obj = ptr.obj[ptr.prop];
-        ptr.prop = sub[i];
+              `sub: ${JSON.stringify(sub.slice(0, i + 1))})`);
       }
-      ptr.obj[ptr.prop] = value;
-      util.callbackify(this._setLocked.bind(this))(key, base.fullValue, callback);
-      this._unlock(key);
-    },
-  ], callback);
+      ptr.obj = ptr.obj[ptr.prop];
+      ptr.prop = sub[i];
+    }
+    ptr.obj[ptr.prop] = value;
+    p = this._setLocked(key, base.fullValue);
+  } finally {
+    this._unlock(key);
+  }
+  await p;
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -342,28 +342,28 @@ exports.Database.prototype.findKeys = async function (key, notKey) {
 /**
  * Remove a record from the database
  */
-exports.Database.prototype.remove = function (key, bufferCallback, writeCallback) {
+exports.Database.prototype.remove = function (key, callback) {
   if (this.logger.isDebugEnabled()) this.logger.debug(`DELETE - ${key} - from database `);
-  this.set(key, null, bufferCallback, writeCallback);
+  this.set(key, null, callback);
 };
 
 /**
  Sets the value trough the wrapper
 */
-exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
-  const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
-  this._lock(key).then(() => this._setLocked(key, value, bcb, writeCallback));
+exports.Database.prototype.set = function (key, value, callback) {
+  this._lock(key)
+      .then(() => this._setLocked(key, value, callback))
+      .finally(() => this._unlock(key));
 };
 
-exports.Database.prototype._setLocked = function (key, value, bufferCallback, writeCallback) {
+exports.Database.prototype._setLocked = function (key, value, callback) {
   ++this.metrics.writes;
   let entry = this.buffer.get(key);
   // If there is a write of a different value for the same key already in progress then don't update
   // the existing entry object -- create a new entry object instead and replace the old one in
-  // this.buffer. This ensures that the writeCallback for the new value is not called until after
-  // the new value is written. (If the existing entry is updated instead, then the writeCallback for
-  // the new value would be called when the old value is committed, not when the new value is
-  // committed.)
+  // this.buffer. This ensures that the callback for the new value is not called until after the new
+  // value is written. (If the existing entry is updated instead, then the callback for the new
+  // value would be called when the old value is committed, not when the new value is committed.)
   if (!entry || entry.writingInProgress) entry = {};
   else if (entry.dirty) ++this.metrics.writesObsoleted;
   entry.value = value;
@@ -371,13 +371,10 @@ exports.Database.prototype._setLocked = function (key, value, bufferCallback, wr
   // function doesn't need to perform deep comparisons, and setSub() doesn't need to perform a deep
   // copy of the object returned from get().
   if (!entry.dirty) entry.dirty = new SelfContainedPromise();
+  if (callback) entry.dirty.then(() => callback(), (err) => callback(err || new Error(err)));
   // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
   // recently used.
   this.buffer.set(key, entry);
-  if (bufferCallback) setImmediate(bufferCallback);
-  if (writeCallback) {
-    entry.dirty.then(() => writeCallback(), (err) => writeCallback(err || new Error(err)));
-  }
   const buffered = this.settings.writeInterval > 0;
   if (this.logger.isDebugEnabled()) {
     this.logger.debug(
@@ -391,7 +388,7 @@ exports.Database.prototype._setLocked = function (key, value, bufferCallback, wr
 /**
  Sets a subvalue
 */
-exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, writeCallback) {
+exports.Database.prototype.setSub = function (key, sub, value, callback) {
   if (this.logger.isDebugEnabled()) {
     this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
   }
@@ -411,6 +408,7 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
         // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
         // ECMAScript automatically wraps primitives in a temporary wrapper object.
         if (typeof o !== 'object') {
+          this._unlock(key);
           callback(new TypeError(
               `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
               `(key: ${JSON.stringify(key)} ` +
@@ -422,18 +420,10 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
         ptr.prop = sub[i];
       }
       ptr.obj[ptr.prop] = value;
-      const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
-      this._setLocked(key, base.fullValue, bcb, writeCallback);
-      callback(null);
-    },
-  ], (err) => {
-    if (err) {
+      this._setLocked(key, base.fullValue, callback);
       this._unlock(key);
-      if (bufferCallback) bufferCallback(err);
-      if (writeCallback) writeCallback(err);
-      if (!bufferCallback && !writeCallback) throw err;
-    }
-  });
+    },
+  ], callback);
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -175,6 +175,9 @@ exports.Database = function (wrappedDB, settings, logger) {
   //     underlying database and we are awaiting commit.
   this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
 
+  // Maps database key to a Promise that is resolved when the record is unlocked.
+  this._locks = new Map();
+
   // start the write Interval
   this.flushInterval = this.settings.writeInterval > 0
     ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
@@ -193,6 +196,20 @@ exports.Database = function (wrappedDB, settings, logger) {
     }
     return new RegExp(regex);
   };
+};
+
+exports.Database.prototype._lock = async function (key) {
+  while (true) {
+    const l = this._locks.get(key);
+    if (l == null) break;
+    await l;
+  }
+  this._locks.set(key, new SelfContainedPromise());
+};
+
+exports.Database.prototype._unlock = async function (key) {
+  this._locks.get(key).done();
+  this._locks.delete(key);
 };
 
 /**
@@ -216,6 +233,15 @@ exports.Database.prototype.close = async function () {
  Gets the value trough the wrapper.
 */
 exports.Database.prototype.get = async function (key) {
+  await this._lock(key);
+  try {
+    return await this._getLocked(key);
+  } finally {
+    this._unlock(key);
+  }
+};
+
+exports.Database.prototype._getLocked = async function (key) {
   const entry = this.buffer.get(key);
   if (entry != null) {
     if (this.logger.isDebugEnabled()) {
@@ -277,6 +303,11 @@ exports.Database.prototype.remove = function (key, bufferCallback, writeCallback
  Sets the value trough the wrapper
 */
 exports.Database.prototype.set = function (key, value, bufferCallback, writeCallback) {
+  const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
+  this._lock(key).then(() => this._setLocked(key, value, bcb, writeCallback));
+};
+
+exports.Database.prototype._setLocked = function (key, value, bufferCallback, writeCallback) {
   let entry = this.buffer.get(key);
   // If there is a write of a different value for the same key already in progress then don't update
   // the existing entry object -- create a new entry object instead and replace the old one in
@@ -316,10 +347,9 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
   }
 
   async.waterfall([
+    util.callbackify(this._lock.bind(this, key)),
     // get the full value
-    (callback) => {
-      util.callbackify(this.get.bind(this))(key, callback);
-    },
+    util.callbackify(this._getLocked.bind(this, key)),
     // set the sub value and set the full value again
     (fullValue, callback) => {
       const base = {fullValue};
@@ -342,11 +372,13 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
         ptr.prop = sub[i];
       }
       ptr.obj[ptr.prop] = value;
-      this.set(key, base.fullValue, bufferCallback, writeCallback);
+      const bcb = (err) => { this._unlock(key); if (bufferCallback) bufferCallback(err); };
+      this._setLocked(key, base.fullValue, bcb, writeCallback);
       callback(null);
     },
   ], (err) => {
     if (err) {
+      this._unlock(key);
       if (bufferCallback) bufferCallback(err);
       if (writeCallback) writeCallback(err);
       if (!bufferCallback && !writeCallback) throw err;
@@ -360,27 +392,32 @@ exports.Database.prototype.setSub = function (key, sub, value, bufferCallback, w
  *     "bla"]
  */
 exports.Database.prototype.getSub = async function (key, sub) {
-  // get the full value
-  const value = await this.get(key);
+  await this._lock(key);
+  try {
+    // get the full value
+    const value = await this._getLocked(key);
 
-  // everything is correct, navigate to the subvalue and return it
-  let subvalue = value;
+    // everything is correct, navigate to the subvalue and return it
+    let subvalue = value;
 
-  for (let i = 0; i < sub.length; i++) {
-    // test if the subvalue exist
-    if (subvalue != null && subvalue[sub[i]] !== undefined) {
-      subvalue = subvalue[sub[i]];
-    } else {
-      // the subvalue doesn't exist, break the loop and return null
-      subvalue = null;
-      break;
+    for (let i = 0; i < sub.length; i++) {
+      // test if the subvalue exist
+      if (subvalue != null && subvalue[sub[i]] !== undefined) {
+        subvalue = subvalue[sub[i]];
+      } else {
+        // the subvalue doesn't exist, break the loop and return null
+        subvalue = null;
+        break;
+      }
     }
-  }
 
-  if (this.logger.isDebugEnabled()) {
-    this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
+    }
+    return subvalue;
+  } finally {
+    this._unlock(key);
   }
-  return subvalue;
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -342,9 +342,9 @@ exports.Database.prototype.findKeys = async function (key, notKey) {
 /**
  * Remove a record from the database
  */
-exports.Database.prototype.remove = function (key, callback) {
+exports.Database.prototype.remove = async function (key) {
   if (this.logger.isDebugEnabled()) this.logger.debug(`DELETE - ${key} - from database `);
-  util.callbackify(this.set.bind(this))(key, null, callback);
+  await this.set(key, null);
 };
 
 /**

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -344,26 +344,33 @@ exports.Database.prototype.findKeys = async function (key, notKey) {
  */
 exports.Database.prototype.remove = function (key, callback) {
   if (this.logger.isDebugEnabled()) this.logger.debug(`DELETE - ${key} - from database `);
-  this.set(key, null, callback);
+  util.callbackify(this.set.bind(this))(key, null, callback);
 };
 
 /**
  Sets the value trough the wrapper
 */
-exports.Database.prototype.set = function (key, value, callback) {
-  this._lock(key)
-      .then(() => this._setLocked(key, value, callback))
-      .finally(() => this._unlock(key));
+exports.Database.prototype.set = async function (key, value) {
+  await this._lock(key);
+  const p = this._setLocked(key, value);
+  this._unlock(key);
+  await p;
 };
 
-exports.Database.prototype._setLocked = function (key, value, callback) {
+// Implementation of the `set()` method. The record must already be locked before calling this. It
+// is safe to unlock the record before the returned Promise resolves.
+exports.Database.prototype._setLocked = async function (key, value) {
+  // IMPORTANT: This function MUST NOT use the `await` keyword before the entry in `this.buffer` is
+  // added/updated. Using `await` causes execution to return to the caller, and the caller must be
+  // able to immediately unlock the record to avoid unnecessary blocking while the value is
+  // committed to the underlying database. If `await` is used before the entry is updated then the
+  // record will be unlocked prematurely, possibly resulting in inconsistent state.
   ++this.metrics.writes;
   let entry = this.buffer.get(key);
   // If there is a write of a different value for the same key already in progress then don't update
   // the existing entry object -- create a new entry object instead and replace the old one in
-  // this.buffer. This ensures that the callback for the new value is not called until after the new
-  // value is written. (If the existing entry is updated instead, then the callback for the new
-  // value would be called when the old value is committed, not when the new value is committed.)
+  // this.buffer. (If the existing entry was updated instead, then entry.dirty would resolve when
+  // the old value is committed, not the new value.)
   if (!entry || entry.writingInProgress) entry = {};
   else if (entry.dirty) ++this.metrics.writesObsoleted;
   entry.value = value;
@@ -371,7 +378,6 @@ exports.Database.prototype._setLocked = function (key, value, callback) {
   // function doesn't need to perform deep comparisons, and setSub() doesn't need to perform a deep
   // copy of the object returned from get().
   if (!entry.dirty) entry.dirty = new SelfContainedPromise();
-  if (callback) entry.dirty.then(() => callback(), (err) => callback(err || new Error(err)));
   // buffer.set() is called even if the value is unchanged so that the cache entry is marked as most
   // recently used.
   this.buffer.set(key, entry);
@@ -382,7 +388,8 @@ exports.Database.prototype._setLocked = function (key, value, callback) {
   }
   // Write it immediately if write buffering is disabled. If write buffering is enabled,
   // this.flush() will eventually take care of it.
-  if (!buffered) this._write([[key, entry]]);
+  if (!buffered) return await this._write([[key, entry]]);
+  await entry.dirty;
 };
 
 /**
@@ -420,7 +427,7 @@ exports.Database.prototype.setSub = function (key, sub, value, callback) {
         ptr.prop = sub[i];
       }
       ptr.obj[ptr.prop] = value;
-      this._setLocked(key, base.fullValue, callback);
+      util.callbackify(this._setLocked.bind(this))(key, base.fullValue, callback);
       this._unlock(key);
     },
   ], callback);
@@ -472,7 +479,9 @@ exports.Database.prototype.flush = async function () {
           if (entry[1].dirty && !entry[1].writingInProgress) dirtyEntries.push(entry);
         }
         if (dirtyEntries.length === 0) return;
-        await this._write(dirtyEntries);
+        try {
+          await this._write(dirtyEntries);
+        } catch (err) { /* intentionally ignored */ }
       }
     })();
   }
@@ -522,6 +531,7 @@ exports.Database.prototype._write = async function (dirtyEntries) {
   // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
   // it should be safe to continue using the memory until the next call to this.buffer.set()
   // evicts the old entries. This saves some CPU cycles at the expense of memory.
+  if (writeErr != null) throw writeErr;
 };
 
 const clone = (obj) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ueberdb2",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,11 +509,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "channels": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/channels/-/channels-0.0.4.tgz",
-      "integrity": "sha1-G+4yPt6hUrue8E9BvG5rD1lIqUE="
-    },
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "async": "^3.2.0",
     "cassandra-driver": "^4.5.1",
-    "channels": "0.0.4",
     "dirty": "^1.1.1",
     "elasticsearch": "^16.7.1",
     "mongodb": "^3.6.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "url": "https://github.com/ether/ueberDB.git"
   },
   "main": "./index",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "bugs": {
     "url": "https://github.com/ether/ueberDB/issues"
   },

--- a/test/test_metrics.js
+++ b/test/test_metrics.js
@@ -1,0 +1,255 @@
+'use strict';
+
+const assert = require('assert').strict;
+const ueberdb = require('../index');
+const util = require('util');
+
+const diffMetrics = (before, after) => {
+  const diff = {};
+  assert.equal(Object.keys(before).length, Object.keys(after).length);
+  for (const [k, bv] of Object.entries(before)) {
+    assert(bv != null);
+    const av = after[k];
+    assert(av != null);
+    if (av - bv > 0) diff[k] = av - bv;
+  }
+  return diff;
+};
+
+describe(__filename, function () {
+  let db;
+  let key;
+  let mock;
+
+  before(async function () {
+    const settings = {};
+    const udb = new ueberdb.Database('mock', settings);
+    mock = settings.mock;
+    db = {metrics: udb.metrics};
+    for (const fn of ['init', 'close', 'get', 'getSub', 'findKeys', 'flush']) {
+      db[fn] = util.promisify(udb[fn].bind(udb));
+    }
+    for (const fn of ['set', 'setSub', 'remove']) {
+      db[fn] = util.promisify((...args) => udb[fn](...args.slice(0, -1), null, ...args.slice(-1)));
+    }
+    mock.once('init', (cb) => cb());
+    await db.init();
+  });
+
+  after(async function () {
+    mock.once('close', (cb) => cb());
+    await db.close();
+  });
+
+  beforeEach(async function () {
+    key = this.currentTest.fullTitle(); // Use test title to avoid collisions with other tests.
+  });
+
+  afterEach(async function () {
+    mock.removeAllListeners();
+  });
+
+  describe('reads', function () {
+    const tcs = [
+      {name: 'get', f: (key) => db.get(key)},
+      {name: 'getSub', f: (key) => db.getSub(key, ['s'])},
+    ];
+
+    for (const tc of tcs) {
+      describe(tc.name, function () {
+        it('cache miss', async function () {
+          let before = {...db.metrics};
+          mock.once('get', (key, cb) => {
+            assert.deepEqual(diffMetrics(before, db.metrics), {lockAcquires: 1, reads: 1});
+            before = {...db.metrics};
+            cb(null, '{"s": "v"}');
+          });
+          await tc.f(key);
+          assert.deepEqual(diffMetrics(before, db.metrics), {lockReleases: 1, readsFinished: 1});
+        });
+
+        it('cache hit', async function () {
+          mock.once('get', (key, cb) => { cb(null, '{"s": "v"}'); });
+          await tc.f(key);
+          const before = {...db.metrics};
+          mock.once('get', (key, cb) => { assert.fail('value should be cached'); });
+          await tc.f(key);
+          assert.deepEqual(diffMetrics(before, db.metrics), {
+            lockAcquires: 1,
+            lockReleases: 1,
+            reads: 1,
+            readsFinished: 1,
+            readsFromCache: 1,
+          });
+        });
+
+        it('read error', async function () {
+          let before = {...db.metrics};
+          mock.once('get', (key, cb) => {
+            assert.deepEqual(diffMetrics(before, db.metrics), {lockAcquires: 1, reads: 1});
+            before = {...db.metrics};
+            cb(new Error('test'));
+          });
+          await assert.rejects(tc.f(key), {message: 'test'});
+          assert.deepEqual(diffMetrics(before, db.metrics), {
+            lockReleases: 1,
+            readsFailed: 1,
+            readsFinished: 1,
+          });
+        });
+
+        it('json error', async function () {
+          let before = {...db.metrics};
+          mock.once('get', (key, cb) => {
+            assert.deepEqual(diffMetrics(before, db.metrics), {lockAcquires: 1, reads: 1});
+            before = {...db.metrics};
+            cb(null, 'ignore me -- this is intentionally invalid json');
+          });
+          await assert.rejects(tc.f(key), {message: /JSON/});
+          assert.deepEqual(diffMetrics(before, db.metrics), {
+            lockReleases: 1,
+            readsFailed: 1,
+            readsFinished: 1,
+          });
+        });
+
+        it('lock contention', async function () {
+          let finishRead;
+          const readStarted = new Promise((resolve) => {
+            mock.once('get', (key, cb) => {
+              resolve();
+              const val = '{"s": "v"}';
+              new Promise((resolve) => { finishRead = resolve; }).then(() => cb(null, val));
+            });
+          });
+          // Note: All contention tests should be with get() to ensure that all functions lock using
+          // the record's key.
+          const p1 = db.get(key);
+          await readStarted;
+          mock.once('get', (key, cb) => { assert.fail('value should be cached'); });
+          const before = {...db.metrics};
+          const p2 = tc.f(key);
+          assert.deepEqual(diffMetrics(before, db.metrics), {lockAwaits: 1});
+          finishRead();
+          assert.deepEqual(await p1, {s: 'v'});
+          await p2;
+        });
+
+        it('read of in-progress write', async function () {
+          let finishWrite;
+          const writeStarted = new Promise((resolve) => {
+            mock.once('set', (key, val, cb) => {
+              resolve();
+              new Promise((resolve) => { finishWrite = resolve; }).then(() => cb());
+            });
+          });
+          const writeFinished = db.set(key, {s: 'v'});
+          const flushed = db.flush(); // Speed up the tests.
+          await writeStarted;
+          await new Promise((resolve) => setImmediate(resolve));
+          mock.once('get', (key, cb) => { assert.fail('value should be cached'); });
+          const before = {...db.metrics};
+          assert.equal(await db.getSub(key, ['s']), 'v');
+          assert.deepEqual(diffMetrics(before, db.metrics), {
+            lockAcquires: 1,
+            lockReleases: 1,
+            reads: 1,
+            readsFinished: 1,
+            readsFromCache: 1,
+          });
+          finishWrite();
+          await writeFinished;
+          await flushed;
+        });
+      });
+    }
+  });
+
+  describe('writes', function () {
+    const tcs = [
+      {name: 'remove', f: (key) => db.remove(key)},
+      {name: 'set', f: (key) => db.set(key, 'v')},
+      {name: 'setSub', fn: 'set', f: (key) => db.setSub(key, ['s'], 'v')},
+      {name: 'doBulk', f: (key) => Promise.all([
+        db.set(key, 'v'),
+        db.set(`${key}2`, 'v'),
+      ]), nOps: 2},
+    ];
+
+    for (const tc of tcs) {
+      if (tc.nOps == null) tc.nOps = 1;
+      if (tc.fn == null) tc.fn = tc.name;
+      describe(tc.name, function () {
+        for (const failWrite of [false, true]) {
+          it(failWrite ? 'error' : 'ok', async function () {
+            // Seed with a value that can be read by the setSub test.
+            mock.once('set', (key, val, cb) => cb());
+            await db.set(key, {s: 'v'});
+            let finishWrite;
+            const writeStarted = new Promise((resolve) => {
+              mock.once(tc.fn, (...args) => {
+                const cb = args.pop();
+                resolve();
+                const err = failWrite ? new Error('test') : null;
+                new Promise((resolve) => { finishWrite = resolve; }).then(() => cb(err));
+              });
+            });
+            let before = {...db.metrics};
+            const writeFinished = tc.f(key);
+            const flushed = db.flush(); // Speed up the tests.
+            await writeStarted;
+            await new Promise((resolve) => setImmediate(resolve));
+            assert.deepEqual(diffMetrics(before, db.metrics), {
+              lockAcquires: tc.nOps,
+              lockReleases: tc.nOps,
+              ...tc.name === 'setSub' ? {
+                reads: 1,
+                readsFinished: 1,
+                readsFromCache: 1,
+              } : {},
+              writes: tc.nOps,
+              writesStarted: tc.nOps,
+            });
+            before = {...db.metrics};
+            finishWrite();
+            await failWrite ? assert.rejects(writeFinished, {message: 'test'}) : writeFinished;
+            await flushed;
+            assert.deepEqual(diffMetrics(before, db.metrics), {
+              writesFinished: tc.nOps,
+              ...failWrite ? {writesFailed: tc.nOps} : {},
+            });
+          });
+        }
+
+        it('lock contention', async function () {
+          let finishRead;
+          const readStarted = new Promise((resolve) => {
+            mock.once('get', (key, cb) => {
+              resolve();
+              const val = '{"s": "v"}';
+              new Promise((resolve) => { finishRead = resolve; }).then(() => cb(null, val));
+            });
+          });
+          // Note: All contention tests should be with get() to ensure that all functions lock using
+          // the record's key.
+          const valP = db.get(key);
+          await readStarted;
+          mock.once(tc.fn, (...args) => args.pop()());
+          const before = {...db.metrics};
+          const writeFinished = tc.f(key);
+          const flushed = db.flush();
+          assert.deepEqual(diffMetrics(before, db.metrics), {
+            ...tc.nOps > 1 ? {
+              lockAcquires: tc.nOps - 1,
+            } : {},
+            lockAwaits: 1,
+          });
+          finishRead();
+          assert.deepEqual(await valP, {s: 'v'});
+          await writeFinished;
+          await flushed;
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Multiple commits:
* cache: Deprecate `bufferCallback` argument
* cache: Promisify `set()`
* cache: Promisify `remove()`
* cache: Promisify `setSub()`
* cache: Avoid calling `util.promisify()` again and again
* cache: Let db drivers declare that they provide async methods

This is marked as draft because it depends on PR #195. Once that PR is merged this can be rebased and marked as ready for review.