### PR TITLE
mysql: Limit bulk query size, increase cache size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Notable Changes
 
+## v1.4.4
+
+* New experimental setting to limit the number of operations written at a time
+  when flushing outstanding writes.
+
 ## v1.4.2
 
 * Refined the experimental read and write metrics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * New experimental setting to limit the number of operations written at a time
   when flushing outstanding writes.
+* `mysql`: Bulk writes are limited to 100 changes at a time to avoid query
+  timeouts.
+* `mysql`: Raised default cache size from 500 entries to 10000.
 
 ## v1.4.2
 

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -38,15 +38,8 @@ exports.Database = function (settings) {
   if (this.settings.charset != null) this.db.charset = this.settings.charset;
 
   this.settings.engine = 'InnoDB';
-  // settings.cache was changed from 1000 to 500.  Testing higer values found that certain queries
-  // were becomming quite large in length causing MySQL Lock to fire which is not terrible
-  // but not ideal if you have a lot of new pads.
-  // Essentially we learned that a lower cache value is better due to concatanated SQL query
-  // length where lots of pads are active.
-  // I actually "think" better values would be cache @ 200 and writeInterval @ 100 but that
-  // would be an overly agressive change for now so 500, 100 seems fine until I can test further
-  this.settings.cache = 500;
-  this.settings.writeInterval = 100;
+  // Limit the query size to avoid timeouts or other failures.
+  this.settings.bulkLimit = 100;
   this.settings.json = true;
 };
 

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -148,33 +148,11 @@ exports.Database = function (wrappedDB, settings, logger) {
   }
   this.logger = logger;
 
-  // apply default settings
-  this.settings = {};
-  this.settings.cache = defaultSettings.cache;
-  this.settings.writeInterval = defaultSettings.writeInterval;
-  this.settings.json = defaultSettings.json;
-  this.settings.charset = defaultSettings.charset;
-
-  // try to apply the settings of the driver
-  if (wrappedDB.settings != null) {
-    if (wrappedDB.settings.cache != null) this.settings.cache = wrappedDB.settings.cache;
-    if (wrappedDB.settings.writeInterval != null) {
-      this.settings.writeInterval = wrappedDB.settings.writeInterval;
-    }
-    if (wrappedDB.settings.json != null) this.settings.json = wrappedDB.settings.json;
-    if (wrappedDB.settings.charset != null) this.settings.charset = wrappedDB.settings.charset;
-  }
-
-  // try to apply the settings given with the constructor
-  if (settings != null) {
-    if (settings.cache != null) this.settings.cache = settings.cache;
-    if (settings.writeInterval != null) this.settings.writeInterval = settings.writeInterval;
-    if (settings.json != null) this.settings.json = settings.json;
-    if (settings.charset != null) this.settings.charset = settings.charset;
-  }
-
-  // freeze the settings at this point
-  this.settings = Object.freeze(this.settings);
+  this.settings = Object.freeze({
+    ...defaultSettings,
+    ...(wrappedDB.settings || {}),
+    ...(settings || {}),
+  });
 
   // The key is the database key. The value is an object with the following properties:
   //   - value: The entry's value.

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -117,6 +117,9 @@ class SelfContainedPromise extends Promise {
 
 const defaultSettings =
 {
+  // Maximum number of operations that can be passed to the wrapped database's doBulk() method.
+  // Falsy means no limit. EXPERIMENTAL.
+  bulkLimit: 0,
   // the number of elements that should be cached. To Disable cache just set it to zero
   cache: 10000,
   // the interval in ms the wrapper writes to the database. To Disable interval writes just set it
@@ -491,7 +494,10 @@ exports.Database.prototype.flush = async function () {
       while (true) {
         const dirtyEntries = [];
         for (const entry of this.buffer) {
-          if (entry[1].dirty && !entry[1].writingInProgress) dirtyEntries.push(entry);
+          if (entry[1].dirty && !entry[1].writingInProgress) {
+            dirtyEntries.push(entry);
+            if (this.settings.bulkLimit && dirtyEntries.length >= this.settings.bulkLimit) break;
+          }
         }
         if (dirtyEntries.length === 0) return;
         await this._write(dirtyEntries);

--- a/test/test_bulk.js
+++ b/test/test_bulk.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('assert').strict;
+const ueberdb = require('../index');
+const util = require('util');
+
+const range = (N) => [...Array(N).keys()];
+
+describe(__filename, function () {
+  describe('bulkLimit', function () {
+    let db;
+    let mock;
+
+    afterEach(async function () {
+      mock.removeAllListeners();
+      mock.once('close', (cb) => cb());
+      await db.close();
+    });
+
+    const bulkLimits = [0, false, null, undefined, '', 1, 2];
+    for (const bulkLimit of bulkLimits) {
+      it(bulkLimit === undefined ? 'undefined' : JSON.stringify(bulkLimit), async function () {
+        const settings = {};
+        const udb = new ueberdb.Database('mock', settings, {bulkLimit, writeInterval: 1});
+        mock = settings.mock;
+        db = {};
+        for (const fn of ['init', 'close', 'set']) db[fn] = util.promisify(udb[fn].bind(udb));
+        mock.once('init', (cb) => cb());
+        await db.init();
+
+        const gotWrites = [];
+        mock.on('set', util.callbackify(async (k, v) => gotWrites.push(1)));
+        mock.on('doBulk', util.callbackify(async (ops) => gotWrites.push(ops.length)));
+        const N = 10;
+        await Promise.all(range(N).map((i) => db.set(`key${i}`, `val${i}`)));
+        const wantLimit = bulkLimit || N;
+        const wantWrites = range(N / wantLimit).map((i) => wantLimit);
+        assert.deepEqual(gotWrites, wantWrites);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Limit bulk writes to 100 operations at a time to avoid timeouts. With the bulk write limit in place it should be safe to increase the cache size so remove the cache size override.

FYI @packardone