### PR TITLE
Provide DB object in wrapper

### DIFF
--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -137,18 +137,18 @@ const defaultSettings =
  @param settings (optional) The settings that should be applied to the wrapper
 */
 exports.Database = function (wrappedDB, settings, logger) {
+  this.wrappedDB = wrappedDB;
+
   // wrappedDB.isAsync is a temporary boolean that will go away once we have migrated all of the
   // database drivers from callback-based methods to async methods.
-  if (wrappedDB.isAsync) {
-    this.wrappedDB = wrappedDB;
-  } else {
-    this.wrappedDB = {};
+  if (!wrappedDB.isAsync) {
     for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
       const f = wrappedDB[fn];
       if (typeof f !== 'function') continue;
       this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
     }
   }
+
   this.logger = logger;
 
   this.settings = Object.freeze({


### PR DESCRIPTION
Backward compatibility with previous versions of ueberdb. 

Allows to access to the db object