### PR TITLE
mysql: Reconnect on fatal error and other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.5
 
 * `mysql`: Reconnect on fatal error.
+* `mysql`: Log MySQL errors.
 
 ## v1.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Notable Changes
 
+## v1.4.5
+
+* `mysql`: Reconnect on fatal error.
+
 ## v1.4.4
 
 * New experimental setting to limit the number of operations written at a time

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -20,6 +20,7 @@ const util = require('util');
 
 exports.Database = class {
   constructor(settings) {
+    this.logger = console;
     // temp hack needs a proper fix..
     if (settings && !settings.charset) settings.charset = 'utf8mb4';
     this.settings = settings;
@@ -111,16 +112,16 @@ exports.Database = class {
 
     result = JSON.parse(JSON.stringify(result));
     if (result[0].DEFAULT_CHARACTER_SET_NAME !== charset) {
-      console.error(`Database is not configured with charset ${charset} -- ` +
-                    'This may lead to crashes when certain characters are pasted in pads');
-      console.log(result[0], charset);
+      this.logger.error(`Database is not configured with charset ${charset} -- ` +
+                        'This may lead to crashes when certain characters are pasted in pads');
+      this.logger.log(result[0], charset);
     }
 
     if (result[0].DEFAULT_COLLATION_NAME.indexOf(charset) === -1) {
-      console.error(
+      this.logger.error(
           `Database is not configured with collation name that includes ${charset} -- ` +
             'This may lead to crashes when certain characters are pasted in pads');
-      console.log(result[0], charset, result[0].DEFAULT_COLLATION_NAME);
+      this.logger.log(result[0], charset, result[0].DEFAULT_COLLATION_NAME);
     }
 
     const tableCharSet =
@@ -135,13 +136,13 @@ exports.Database = class {
       timeout: 60000,
     });
     if (!result[0]) {
-      console.warn('Data has no character_set_name value -- ' +
-                   'This may lead to crashes when certain characters are pasted in pads');
+      this.logger.warn('Data has no character_set_name value -- ' +
+                       'This may lead to crashes when certain characters are pasted in pads');
     }
     if (result[0] && (result[0].character_set_name !== charset)) {
-      console.error(`table is not configured with charset ${charset} -- ` +
-                    'This may lead to crashes when certain characters are pasted in pads');
-      console.log(result[0], charset);
+      this.logger.error(`table is not configured with charset ${charset} -- ` +
+                        'This may lead to crashes when certain characters are pasted in pads');
+      this.logger.log(result[0], charset);
     }
 
     // check migration level, alter if not migrated

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -30,6 +30,7 @@ exports.Database = class {
       // Limit the query size to avoid timeouts or other failures.
       bulkLimit: 100,
       json: true,
+      queryTimeout: 60000,
     };
     // Promise that resolves to a MySQL Connection object.
     this._connection = this._connect();
@@ -71,7 +72,7 @@ exports.Database = class {
     const connection = await this._connection;
     try {
       return await new Promise((resolve, reject) => {
-        options = {timeout: 60000, ...options};
+        options = {timeout: this.settings.queryTimeout, ...options};
         connection.query(options, (err, ...args) => err != null ? reject(err) : resolve(args));
       });
     } catch (err) {

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -17,203 +17,205 @@
 
 const util = require('util');
 
-exports.Database = function (settings) {
-  // temp hack needs a proper fix..
-  if (settings && !settings.charset) settings.charset = 'utf8mb4';
+exports.Database = class {
+  constructor(settings) {
+    // temp hack needs a proper fix..
+    if (settings && !settings.charset) settings.charset = 'utf8mb4';
 
-  this.db = require('mysql').createConnection(settings);
+    this.db = require('mysql').createConnection(settings);
 
-  this.settings = settings;
+    this.settings = settings;
 
-  if (this.settings.host != null) this.db.host = this.settings.host;
+    if (this.settings.host != null) this.db.host = this.settings.host;
 
-  if (this.settings.port != null) this.db.port = this.settings.port;
+    if (this.settings.port != null) this.db.port = this.settings.port;
 
-  if (this.settings.user != null) this.db.user = this.settings.user;
+    if (this.settings.user != null) this.db.user = this.settings.user;
 
-  if (this.settings.password != null) this.db.password = this.settings.password;
+    if (this.settings.password != null) this.db.password = this.settings.password;
 
-  if (this.settings.database != null) this.db.database = this.settings.database;
+    if (this.settings.database != null) this.db.database = this.settings.database;
 
-  if (this.settings.charset != null) this.db.charset = this.settings.charset;
+    if (this.settings.charset != null) this.db.charset = this.settings.charset;
 
-  this.settings.engine = 'InnoDB';
-  // Limit the query size to avoid timeouts or other failures.
-  this.settings.bulkLimit = 100;
-  this.settings.json = true;
-};
-
-exports.Database.prototype.isAsync = true;
-
-exports.Database.prototype._query = async function (...args) {
-  return await new Promise((resolve, reject) => {
-    this.db.query(...args, (err, ...args) => err != null ? reject(err) : resolve(args));
-  });
-};
-
-exports.Database.prototype.clearPing = function () {
-  if (this.interval) {
-    clearInterval(this.interval);
+    this.settings.engine = 'InnoDB';
+    // Limit the query size to avoid timeouts or other failures.
+    this.settings.bulkLimit = 100;
+    this.settings.json = true;
   }
-};
 
-exports.Database.prototype.schedulePing = function () {
-  this.clearPing();
+  get isAsync() { return true; }
 
-  this.interval = setInterval(() => {
-    this.db.query({
-      sql: 'SELECT 1',
-      timeout: 60000,
+  async _query(...args) {
+    return await new Promise((resolve, reject) => {
+      this.db.query(...args, (err, ...args) => err != null ? reject(err) : resolve(args));
     });
-  }, 10000);
-};
+  }
 
-exports.Database.prototype.init = async function () {
-  const db = this.db;
+  clearPing() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
 
-  const sqlCreate = `${'CREATE TABLE IF NOT EXISTS `store` ( ' +
+  schedulePing() {
+    this.clearPing();
+
+    this.interval = setInterval(() => {
+      this.db.query({
+        sql: 'SELECT 1',
+        timeout: 60000,
+      });
+    }, 10000);
+  }
+
+  async init() {
+    const db = this.db;
+
+    const sqlCreate = `${'CREATE TABLE IF NOT EXISTS `store` ( ' +
                   '`key` VARCHAR( 100 ) NOT NULL COLLATE utf8mb4_bin, ' +
                   '`value` LONGTEXT COLLATE utf8mb4_bin NOT NULL , ' +
                   'PRIMARY KEY ( `key` ) ' +
                   ') ENGINE='}${this.settings.engine} CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`;
 
-  const sqlAlter = 'ALTER TABLE store MODIFY `key` VARCHAR(100) COLLATE utf8mb4_bin;';
+    const sqlAlter = 'ALTER TABLE store MODIFY `key` VARCHAR(100) COLLATE utf8mb4_bin;';
 
-  await this._query({
-    sql: sqlCreate,
-    timeout: 60000,
-  }, []);
-
-  // Checks for Database charset et al
-  const dbCharSet =
-      'SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME ' +
-      `FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '${db.database}'`;
-  let [result] = await this._query({
-    sql: dbCharSet,
-    timeout: 60000,
-  });
-
-  result = JSON.parse(JSON.stringify(result));
-  if (result[0].DEFAULT_CHARACTER_SET_NAME !== db.charset) {
-    console.error(`Database is not configured with charset ${db.charset} -- ` +
-                  'This may lead to crashes when certain characters are pasted in pads');
-    console.log(result[0], db.charset);
-  }
-
-  if (result[0].DEFAULT_COLLATION_NAME.indexOf(db.charset) === -1) {
-    console.error(
-        `Database is not configured with collation name that includes ${db.charset} -- ` +
-          'This may lead to crashes when certain characters are pasted in pads');
-    console.log(result[0], db.charset, result[0].DEFAULT_COLLATION_NAME);
-  }
-
-  const tableCharSet =
-      'SELECT CCSA.character_set_name AS character_set_name ' +
-      'FROM information_schema.`TABLES` ' +
-      'T,information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA ' +
-      'WHERE CCSA.collation_name = T.table_collation ' +
-      `AND T.table_schema = '${db.database}' ` +
-      "AND T.table_name = 'store'";
-  [result] = await this._query({
-    sql: tableCharSet,
-    timeout: 60000,
-  });
-  if (!result[0]) {
-    console.warn('Data has no character_set_name value -- ' +
-                 'This may lead to crashes when certain characters are pasted in pads');
-  }
-  if (result[0] && (result[0].character_set_name !== db.charset)) {
-    console.error(`table is not configured with charset ${db.charset} -- ` +
-                  'This may lead to crashes when certain characters are pasted in pads');
-    console.log(result[0], db.charset);
-  }
-
-  // check migration level, alter if not migrated
-  const level = await this.get('MYSQL_MIGRATION_LEVEL');
-
-  if (level !== '1') {
     await this._query({
-      sql: sqlAlter,
+      sql: sqlCreate,
       timeout: 60000,
     }, []);
-    await this.set('MYSQL_MIGRATION_LEVEL', '1');
-  }
 
-  this.schedulePing();
-};
+    // Checks for Database charset et al
+    const dbCharSet =
+        'SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME ' +
+        `FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '${db.database}'`;
+    let [result] = await this._query({
+      sql: dbCharSet,
+      timeout: 60000,
+    });
 
-exports.Database.prototype.get = async function (key) {
-  const [results] = await this._query({
-    sql: 'SELECT `value` FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
-    timeout: 60000,
-  }, [key, key]);
-  this.schedulePing();
-  return results.length === 1 ? results[0].value : null;
-};
-
-exports.Database.prototype.findKeys = async function (key, notKey) {
-  let query = 'SELECT `key` FROM `store` WHERE `key` LIKE ?';
-  const params = [];
-
-  // desired keys are key, e.g. pad:%
-  key = key.replace(/\*/g, '%');
-  params.push(key);
-
-  if (notKey != null) {
-    // not desired keys are notKey, e.g. %:%:%
-    notKey = notKey.replace(/\*/g, '%');
-    query += ' AND `key` NOT LIKE ?';
-    params.push(notKey);
-  }
-  const [results] = await this._query({
-    sql: query,
-    timeout: 60000,
-  }, params);
-  this.schedulePing();
-  return results.map((val) => val.key);
-};
-
-exports.Database.prototype.set = async function (key, value) {
-  if (key.length > 100) throw new Error('Your Key can only be 100 chars');
-  await this._query({
-    sql: 'REPLACE INTO `store` VALUES (?,?)',
-    timeout: 60000,
-  }, [key, value]);
-  this.schedulePing();
-};
-
-exports.Database.prototype.remove = async function (key) {
-  await this._query({
-    sql: 'DELETE FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
-    timeout: 60000,
-  }, [key, key]);
-  this.schedulePing();
-};
-
-exports.Database.prototype.doBulk = async function (bulk) {
-  const replaces = [];
-  const deletes = [];
-  for (const op of bulk) {
-    switch (op.type) {
-      case 'set': replaces.push([op.key, op.value]); break;
-      case 'remove': deletes.push(op.key); break;
-      default: throw new Error(`unknown op type: ${op.type}`);
+    result = JSON.parse(JSON.stringify(result));
+    if (result[0].DEFAULT_CHARACTER_SET_NAME !== db.charset) {
+      console.error(`Database is not configured with charset ${db.charset} -- ` +
+                    'This may lead to crashes when certain characters are pasted in pads');
+      console.log(result[0], db.charset);
     }
-  }
-  await Promise.all([
-    replaces.length ? this._query({
-      sql: 'REPLACE INTO `store` VALUES ?;',
-      timeout: 60000,
-    }, [replaces]) : null,
-    deletes.length ? this._query({
-      sql: 'DELETE FROM `store` WHERE `key` IN (?) AND BINARY `key` IN (?);',
-      timeout: 60000,
-    }, [deletes, deletes]) : null,
-  ]);
-  this.schedulePing();
-};
 
-exports.Database.prototype.close = async function () {
-  this.clearPing();
-  await util.promisify(this.db.end.bind(this.db))();
+    if (result[0].DEFAULT_COLLATION_NAME.indexOf(db.charset) === -1) {
+      console.error(
+          `Database is not configured with collation name that includes ${db.charset} -- ` +
+            'This may lead to crashes when certain characters are pasted in pads');
+      console.log(result[0], db.charset, result[0].DEFAULT_COLLATION_NAME);
+    }
+
+    const tableCharSet =
+        'SELECT CCSA.character_set_name AS character_set_name ' +
+        'FROM information_schema.`TABLES` ' +
+        'T,information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA ' +
+        'WHERE CCSA.collation_name = T.table_collation ' +
+        `AND T.table_schema = '${db.database}' ` +
+        "AND T.table_name = 'store'";
+    [result] = await this._query({
+      sql: tableCharSet,
+      timeout: 60000,
+    });
+    if (!result[0]) {
+      console.warn('Data has no character_set_name value -- ' +
+                   'This may lead to crashes when certain characters are pasted in pads');
+    }
+    if (result[0] && (result[0].character_set_name !== db.charset)) {
+      console.error(`table is not configured with charset ${db.charset} -- ` +
+                    'This may lead to crashes when certain characters are pasted in pads');
+      console.log(result[0], db.charset);
+    }
+
+    // check migration level, alter if not migrated
+    const level = await this.get('MYSQL_MIGRATION_LEVEL');
+
+    if (level !== '1') {
+      await this._query({
+        sql: sqlAlter,
+        timeout: 60000,
+      }, []);
+      await this.set('MYSQL_MIGRATION_LEVEL', '1');
+    }
+
+    this.schedulePing();
+  }
+
+  async get(key) {
+    const [results] = await this._query({
+      sql: 'SELECT `value` FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
+      timeout: 60000,
+    }, [key, key]);
+    this.schedulePing();
+    return results.length === 1 ? results[0].value : null;
+  }
+
+  async findKeys(key, notKey) {
+    let query = 'SELECT `key` FROM `store` WHERE `key` LIKE ?';
+    const params = [];
+
+    // desired keys are key, e.g. pad:%
+    key = key.replace(/\*/g, '%');
+    params.push(key);
+
+    if (notKey != null) {
+      // not desired keys are notKey, e.g. %:%:%
+      notKey = notKey.replace(/\*/g, '%');
+      query += ' AND `key` NOT LIKE ?';
+      params.push(notKey);
+    }
+    const [results] = await this._query({
+      sql: query,
+      timeout: 60000,
+    }, params);
+    this.schedulePing();
+    return results.map((val) => val.key);
+  }
+
+  async set(key, value) {
+    if (key.length > 100) throw new Error('Your Key can only be 100 chars');
+    await this._query({
+      sql: 'REPLACE INTO `store` VALUES (?,?)',
+      timeout: 60000,
+    }, [key, value]);
+    this.schedulePing();
+  }
+
+  async remove(key) {
+    await this._query({
+      sql: 'DELETE FROM `store` WHERE `key` = ? AND BINARY `key` = ?',
+      timeout: 60000,
+    }, [key, key]);
+    this.schedulePing();
+  }
+
+  async doBulk(bulk) {
+    const replaces = [];
+    const deletes = [];
+    for (const op of bulk) {
+      switch (op.type) {
+        case 'set': replaces.push([op.key, op.value]); break;
+        case 'remove': deletes.push(op.key); break;
+        default: throw new Error(`unknown op type: ${op.type}`);
+      }
+    }
+    await Promise.all([
+      replaces.length ? this._query({
+        sql: 'REPLACE INTO `store` VALUES ?;',
+        timeout: 60000,
+      }, [replaces]) : null,
+      deletes.length ? this._query({
+        sql: 'DELETE FROM `store` WHERE `key` IN (?) AND BINARY `key` IN (?);',
+        timeout: 60000,
+      }, [deletes, deletes]) : null,
+    ]);
+    this.schedulePing();
+  }
+
+  async close() {
+    this.clearPing();
+    await util.promisify(this.db.end.bind(this.db))();
+  }
 };

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+const util = require('util');
+
 exports.Database = function (settings) {
   // temp hack needs a proper fix..
   if (settings && !settings.charset) settings.charset = 'utf8mb4';
@@ -211,7 +213,7 @@ exports.Database.prototype.doBulk = async function (bulk) {
   this.schedulePing();
 };
 
-exports.Database.prototype.close = function (callback) {
+exports.Database.prototype.close = async function () {
   this.clearPing();
-  this.db.end(callback);
+  await util.promisify(this.db.end.bind(this.db))();
 };

--- a/test/test_mysql.js
+++ b/test/test_mysql.js
@@ -12,6 +12,8 @@ describe(__filename, function () {
   it('connect error is detected during init()', async function () {
     // Use an invalid TCP port to force a connection error.
     const db = new mysql.Database({...databases.mysql, port: 65536});
+    // An error is expected; prevent it from being logged.
+    db.logger = Object.setPrototypeOf({error() {}}, db.logger);
     await assert.rejects(db.init());
   });
 
@@ -19,6 +21,8 @@ describe(__filename, function () {
     const db = new mysql.Database(databases.mysql);
     await db.init();
     const before = await db._connection;
+    // An error is expected; prevent it from being logged.
+    db.logger = Object.setPrototypeOf({error() {}}, db.logger);
     // Sleep longer than the timeout to force a fatal error.
     await assert.rejects(db._query({sql: 'DO SLEEP(1);', timeout: 1}), {fatal: true});
     const after = await db._connection;

--- a/test/test_mysql.js
+++ b/test/test_mysql.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert').strict;
+const {databases} = require('./lib/databases');
+const mysql = require('../databases/mysql_db');
+
+describe(__filename, function () {
+  beforeEach(async function () {
+    if (databases.mysql == null) return this.skip();
+  });
+
+  it('connect error is detected during init()', async function () {
+    // Use an invalid TCP port to force a connection error.
+    const db = new mysql.Database({...databases.mysql, port: 65536});
+    await assert.rejects(db.init());
+  });
+
+  it('reconnect after fatal error', async function () {
+    const db = new mysql.Database(databases.mysql);
+    await db.init();
+    const before = await db._connection;
+    // Sleep longer than the timeout to force a fatal error.
+    await assert.rejects(db._query({sql: 'DO SLEEP(1);', timeout: 1}), {fatal: true});
+    const after = await db._connection;
+    assert.notEqual(after, before);
+    await db.close();
+  });
+});

--- a/test/test_mysql.js
+++ b/test/test_mysql.js
@@ -29,4 +29,15 @@ describe(__filename, function () {
     assert.notEqual(after, before);
     await db.close();
   });
+
+  it('query times out', async function () {
+    const db = new mysql.Database(databases.mysql);
+    await db.init();
+    // Timeout error messages are expected; prevent them from being logged.
+    db.logger = Object.setPrototypeOf({error() {}}, db.logger);
+    db.settings.queryTimeout = 100;
+    await assert.doesNotReject(db._query({sql: 'DO SLEEP(0.090);'}));
+    await assert.rejects(db._query({sql: 'DO SLEEP(0.110);'}));
+    await db.close();
+  });
 });


### PR DESCRIPTION
Multiple commits:
* mysql: Promisify `close()`
* mysql: Use ES6 class syntax for readability
* mysql: Avoid adding properties to the connection object
* mysql: Reconnect on fatal error
* mysql: Add ability to set logger object
* mysql: Log MySQL errors
* mysql: Pass query values via options object
* mysql: Move timeout into `_query()`
* mysql: Separate MySQL settings from ueberdb settings
* mysql: Move default query timeout to settings
* mysql: Reschedule ping after each connect and query

cc @packardone