### PR TITLE
cache: If bulk write fails, retry each write individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Notable Changes
 
+## v1.4.7
+
+* Fixed write metrics for `setSub()` read failures.
+
 ## v1.4.6
 
 * `mysql`: Use a connection pool to improve performance and simplify the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.4.7
 
+* Each write operation in a bulk write batch is now retried if the bulk write
+  fails.
 * Fixed write metrics for `setSub()` read failures.
 
 ## v1.4.6

--- a/databases/mock_db.js
+++ b/databases/mock_db.js
@@ -5,7 +5,10 @@ const events = require('events');
 exports.Database = class extends events.EventEmitter {
   constructor(settings) {
     super();
-    this.settings = settings;
+    this.settings = {
+      writeInterval: 1,
+      ...settings,
+    };
     settings.mock = this;
   }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const util = require('util');
 // Returns a logger derived from the given logger (which may be null) that has debug() and
 // isDebugEnabled() methods.
 const normalizeLogger = (logger) => {
-  const logLevelsUsed = ['debug'];
+  const logLevelsUsed = ['debug', 'error'];
   logger = Object.create(logger || {});
   for (const level of logLevelsUsed) {
     const enabledFnName = `is${level.charAt(0).toUpperCase() + level.slice(1)}Enabled`;

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -314,7 +314,7 @@ exports.Database.prototype._getLocked = async function (key) {
       try {
         value = JSON.parse(value);
       } catch (err) {
-        console.error(`JSON-PROBLEM:${value}`);
+        this.logger.error(`JSON-PROBLEM:${value}`);
         throw err;
       }
     }

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -209,15 +209,18 @@ exports.Database = function (wrappedDB, settings, logger) {
     // Count of times a pending write operation was not sent to the underlying database because a
     // call to `remove()`, `set()`, or `setSub()` superseded the write, rendering it unnecessary.
     writesObsoleted: 0,
-    // Count of times a value was sent to the underlying database (including record deletes). This
-    // minus `writesToDbFinished` is the number of in-progress writes.
+    // Count of times a value was sent to the underlying database, including record deletes but
+    // excluding retries. This minus `writesToDbFinished` is the number of in-progress writes.
     writesToDb: 0,
-    // Count of times the database failed to write a value (including failed record deletes). This
-    // does not include JSON serialization errors.
+    // Count of times ueberDB failed to write a change to the underlying database, including failed
+    // record deletes. This does not include JSON serialization errors or write errors that later
+    // succeeded thanks to a retry by ueberDB.
     writesToDbFailed: 0,
     // Count of completed (successful or failed) value writes to the database. This plus
     // `writesObsoleted` equals `writesFinished`.
     writesToDbFinished: 0,
+    // Count of times a write operation was retried.
+    writesToDbRetried: 0,
   };
 
   // start the write Interval
@@ -519,13 +522,18 @@ exports.Database.prototype.flush = async function () {
 
 exports.Database.prototype._write = async function (dirtyEntries) {
   const markDone = (entry, err) => {
-    entry.writingInProgress = false;
-    // If err != null then the entry is stil technically dirty, but the responsibility is on the
+    if (entry.writingInProgress) {
+      entry.writingInProgress = false;
+      if (err != null) ++this.metrics.writesToDbFailed;
+      ++this.metrics.writesToDbFinished;
+    }
+    // If err != null then the entry is still technically dirty, but the responsibility is on the
     // user to retry failures so from ueberDB's perspective the entry is no longer dirty.
     entry.dirty.done(err);
     entry.dirty = null;
   };
   const ops = [];
+  const entries = [];
   for (const [key, entry] of dirtyEntries) {
     let value = entry.value;
     try {
@@ -536,32 +544,43 @@ exports.Database.prototype._write = async function (dirtyEntries) {
     }
     entry.writingInProgress = true;
     ops.push({type: value == null ? 'remove' : 'set', key, value});
+    entries.push(entry);
   }
   if (ops.length === 0) return;
   this.metrics.writesToDb += ops.length;
-  let writeErr = null;
-  try {
-    if (ops.length === 1) {
-      const {type, key, value} = ops[0];
-      switch (type) {
+  const writeOneOp = async (op, entry) => {
+    let writeErr = null;
+    try {
+      switch (op.type) {
         case 'remove':
-          await this.wrappedDB.remove(key);
+          await this.wrappedDB.remove(op.key);
           break;
         case 'set':
-          await this.wrappedDB.set(key, value);
+          await this.wrappedDB.set(op.key, op.value);
           break;
         default:
-          throw new Error(`unsupported operation type: ${type}`);
+          throw new Error(`unsupported operation type: ${op.type}`);
       }
-    } else {
-      await this.wrappedDB.doBulk(ops);
+    } catch (err) {
+      writeErr = err || new Error(err);
     }
-  } catch (err) {
-    writeErr = err || new Error(err);
-    this.metrics.writesToDbFailed += ops.length;
+    markDone(entry, writeErr);
+  };
+  if (ops.length === 1) {
+    await writeOneOp(ops[0], entries[0]);
+  } else {
+    let success = false;
+    try {
+      await this.wrappedDB.doBulk(ops);
+      success = true;
+    } catch (err) {
+      this.logger.error(
+          `Bulk write of ${ops.length} ops failed, retrying individually: ${err.stack || err}`);
+      this.metrics.writesToDbRetried += ops.length;
+      await Promise.all(ops.map(async (op, i) => await writeOneOp(op, entries[i])));
+    }
+    if (success) entries.forEach((entry) => markDone(entry, null));
   }
-  this.metrics.writesToDbFinished += ops.length;
-  for (const [, entry] of dirtyEntries) markDone(entry, writeErr);
   // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
   // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
   // it should be safe to continue using the memory until the next call to this.buffer.set()

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -424,26 +424,35 @@ exports.Database.prototype.setSub = async function (key, sub, value) {
   let p;
   await this._lock(key);
   try {
-    const fullValue = await this._getLocked(key);
-    const base = {fullValue};
-    // Emulate a pointer to the property that should be set to `value`.
-    const ptr = {obj: base, prop: 'fullValue'};
-    for (let i = 0; i < sub.length; i++) {
-      let o = ptr.obj[ptr.prop];
-      if (o == null) ptr.obj[ptr.prop] = o = {};
-      // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
-      // ECMAScript automatically wraps primitives in a temporary wrapper object.
-      if (typeof o !== 'object') {
-        throw new TypeError(
-            `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
-              `(key: ${JSON.stringify(key)} ` +
-              `value in db: ${JSON.stringify(fullValue)} ` +
-              `sub: ${JSON.stringify(sub.slice(0, i + 1))})`);
+    let base;
+    try {
+      const fullValue = await this._getLocked(key);
+      base = {fullValue};
+      // Emulate a pointer to the property that should be set to `value`.
+      const ptr = {obj: base, prop: 'fullValue'};
+      for (let i = 0; i < sub.length; i++) {
+        let o = ptr.obj[ptr.prop];
+        if (o == null) ptr.obj[ptr.prop] = o = {};
+        // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
+        // ECMAScript automatically wraps primitives in a temporary wrapper object.
+        if (typeof o !== 'object') {
+          throw new TypeError(
+              `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
+                `(key: ${JSON.stringify(key)} ` +
+                `value in db: ${JSON.stringify(fullValue)} ` +
+                `sub: ${JSON.stringify(sub.slice(0, i + 1))})`);
+        }
+        ptr.obj = ptr.obj[ptr.prop];
+        ptr.prop = sub[i];
       }
-      ptr.obj = ptr.obj[ptr.prop];
-      ptr.prop = sub[i];
+      ptr.obj[ptr.prop] = value;
+    } catch (err) {
+      // this._setLocked() will not be called but it should still count as a write failure.
+      ++this.metrics.writes;
+      ++this.metrics.writesFailed;
+      ++this.metrics.writesFinished;
+      throw err;
     }
-    ptr.obj[ptr.prop] = value;
     p = this._setLocked(key, base.fullValue);
   } finally {
     this._unlock(key);

--- a/test/test_bulk.js
+++ b/test/test_bulk.js
@@ -7,27 +7,35 @@ const util = require('util');
 const range = (N) => [...Array(N).keys()];
 
 describe(__filename, function () {
-  describe('bulkLimit', function () {
-    let db;
-    let mock;
+  let db = null;
+  let mock = null;
+  const createDb = async (wrapperSettings) => {
+    const settings = {};
+    const udb = new ueberdb.Database('mock', settings, wrapperSettings);
+    mock = settings.mock;
+    db = {};
+    for (const fn of ['init', 'close', 'set']) db[fn] = util.promisify(udb[fn].bind(udb));
+    mock.once('init', (cb) => cb());
+    await db.init();
+  };
 
-    afterEach(async function () {
+  afterEach(async function () {
+    if (mock != null) {
       mock.removeAllListeners();
       mock.once('close', (cb) => cb());
+      mock = null;
+    }
+    if (db != null) {
       await db.close();
-    });
+      db = null;
+    }
+  });
 
+  describe('bulkLimit', function () {
     const bulkLimits = [0, false, null, undefined, '', 1, 2];
     for (const bulkLimit of bulkLimits) {
       it(bulkLimit === undefined ? 'undefined' : JSON.stringify(bulkLimit), async function () {
-        const settings = {};
-        const udb = new ueberdb.Database('mock', settings, {bulkLimit});
-        mock = settings.mock;
-        db = {};
-        for (const fn of ['init', 'close', 'set']) db[fn] = util.promisify(udb[fn].bind(udb));
-        mock.once('init', (cb) => cb());
-        await db.init();
-
+        await createDb({bulkLimit});
         const gotWrites = [];
         mock.on('set', util.callbackify(async (k, v) => gotWrites.push(1)));
         mock.on('doBulk', util.callbackify(async (ops) => gotWrites.push(ops.length)));
@@ -38,5 +46,26 @@ describe(__filename, function () {
         assert.deepEqual(gotWrites, wantWrites);
       });
     }
+  });
+
+  it('bulk failures are retried individually', async function () {
+    await createDb({});
+    const gotDoBulkCalls = [];
+    mock.on('doBulk', util.callbackify(async (ops) => {
+      gotDoBulkCalls.push(ops.length);
+      throw new Error('test');
+    }));
+    const gotWrites = new Map();
+    const wantWrites = new Map();
+    mock.on('set', util.callbackify(async (k, v) => gotWrites.set(k, v)));
+    const N = 10;
+    await Promise.all(range(N).map(async (i) => {
+      const k = `key${i}`;
+      const v = `val${i}`;
+      wantWrites.set(k, JSON.stringify(v));
+      await db.set(k, v);
+    }));
+    assert.deepEqual(gotDoBulkCalls, [N]);
+    assert.deepEqual(gotWrites, wantWrites);
   });
 });

--- a/test/test_bulk.js
+++ b/test/test_bulk.js
@@ -21,7 +21,7 @@ describe(__filename, function () {
     for (const bulkLimit of bulkLimits) {
       it(bulkLimit === undefined ? 'undefined' : JSON.stringify(bulkLimit), async function () {
         const settings = {};
-        const udb = new ueberdb.Database('mock', settings, {bulkLimit, writeInterval: 1});
+        const udb = new ueberdb.Database('mock', settings, {bulkLimit});
         mock = settings.mock;
         db = {};
         for (const fn of ['init', 'close', 'set']) db[fn] = util.promisify(udb[fn].bind(udb));

--- a/test/test_metrics.js
+++ b/test/test_metrics.js
@@ -189,14 +189,14 @@ describe(__filename, function () {
         action: async () => await db.remove(key),
         wantOps: [
           {
-            wantFn: 'remove',
+            wantFns: ['remove'],
             wantMetricsDelta: {
               lockAcquires: 1,
               lockReleases: 1,
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [null],
+            cbArgs: [[null]],
           },
         ],
         wantErr: null,
@@ -210,14 +210,14 @@ describe(__filename, function () {
         action: async () => await db.remove(key),
         wantOps: [
           {
-            wantFn: 'remove',
+            wantFns: ['remove'],
             wantMetricsDelta: {
               lockAcquires: 1,
               lockReleases: 1,
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('test')]],
           },
         ],
         wantErr: {message: 'test'},
@@ -233,14 +233,14 @@ describe(__filename, function () {
         action: async () => await db.set(key, 'v'),
         wantOps: [
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockAcquires: 1,
               lockReleases: 1,
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [null],
+            cbArgs: [[null]],
           },
         ],
         wantErr: null,
@@ -254,14 +254,14 @@ describe(__filename, function () {
         action: async () => await db.set(key, 'v'),
         wantOps: [
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockAcquires: 1,
               lockReleases: 1,
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('test')]],
           },
         ],
         wantErr: {message: 'test'},
@@ -290,16 +290,16 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [null, '{"s": "v1"}'],
+            cbArgs: [[null, '{"s": "v1"}']],
           },
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockReleases: 1,
               readsFinished: 1,
@@ -307,7 +307,7 @@ describe(__filename, function () {
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [null],
+            cbArgs: [[null]],
           },
         ],
         wantErr: null,
@@ -321,16 +321,16 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [null, '{"s": "v1"}'],
+            cbArgs: [[null, '{"s": "v1"}']],
           },
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockReleases: 1,
               readsFinished: 1,
@@ -338,7 +338,7 @@ describe(__filename, function () {
               writes: 1,
               writesToDb: 1,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('test')]],
           },
         ],
         wantErr: {message: 'test'},
@@ -354,13 +354,13 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('test')]],
           },
         ],
         wantErr: {message: 'test'},
@@ -380,13 +380,13 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [null, 'ignore me -- this is intentionally invalid json'],
+            cbArgs: [[null, 'ignore me -- this is intentionally invalid json']],
           },
         ],
         wantErr: {name: 'SyntaxError'},
@@ -405,13 +405,13 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [null, '"foo"'],
+            cbArgs: [[null, '"foo"']],
           },
         ],
         wantErr: {message: /non-object/},
@@ -429,13 +429,13 @@ describe(__filename, function () {
         action: async () => await db.setSub(key, ['s'], BigInt(1)), // BigInts are not JSONable.
         wantOps: [
           {
-            wantFn: 'get',
+            wantFns: ['get'],
             wantMetricsDelta: {
               lockAcquires: 1,
               reads: 1,
               readsFromDb: 1,
             },
-            cbArgs: [null, '{"s": "v1"}'],
+            cbArgs: [[null, '{"s": "v1"}']],
           },
         ],
         wantErr: {name: 'TypeError'},
@@ -453,14 +453,14 @@ describe(__filename, function () {
         action: async () => await Promise.all([db.set(key, 'v'), db.set(`${key} second op`, 'v')]),
         wantOps: [
           {
-            wantFn: 'doBulk',
+            wantFns: ['doBulk'],
             wantMetricsDelta: {
               lockAcquires: 2,
               lockReleases: 2,
               writes: 2,
               writesToDb: 2,
             },
-            cbArgs: [null],
+            cbArgs: [[null]],
           },
         ],
         wantErr: null,
@@ -470,21 +470,86 @@ describe(__filename, function () {
         },
       },
       {
-        name: 'doBulk error',
+        name: 'doBulk error, all retries ok',
         action: async () => await Promise.all([db.set(key, 'v'), db.set(`${key} second op`, 'v')]),
         wantOps: [
           {
-            wantFn: 'doBulk',
+            wantFns: ['doBulk'],
             wantMetricsDelta: {
               lockAcquires: 2,
               lockReleases: 2,
               writes: 2,
               writesToDb: 2,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('injected doBulk error')]],
+          },
+          {
+            wantFns: ['set', 'set'],
+            wantMetricsDelta: {
+              writesToDbRetried: 2,
+            },
+            cbArgs: [[null], [null]],
+          },
+        ],
+        wantErr: null,
+        wantMetricsDelta: {
+          writesFinished: 2,
+          writesToDbFinished: 2,
+        },
+      },
+      {
+        name: 'doBulk error, one of the retries fails',
+        action: async () => await Promise.all([db.set(key, 'v'), db.set(`${key} second op`, 'v')]),
+        wantOps: [
+          {
+            wantFns: ['doBulk'],
+            wantMetricsDelta: {
+              lockAcquires: 2,
+              lockReleases: 2,
+              writes: 2,
+              writesToDb: 2,
+            },
+            cbArgs: [[new Error('injected doBulk error')]],
+          },
+          {
+            wantFns: ['set', 'set'],
+            wantMetricsDelta: {
+              writesToDbRetried: 2,
+            },
+            cbArgs: [[new Error('test')], [null]],
           },
         ],
         wantErr: {message: 'test'},
+        wantMetricsDelta: {
+          writesFailed: 1,
+          writesFinished: 2,
+          writesToDbFailed: 1,
+          writesToDbFinished: 2,
+        },
+      },
+      {
+        name: 'doBulk error, all retries fail',
+        action: async () => await Promise.all([db.set(key, 'v'), db.set(`${key} second op`, 'v')]),
+        wantOps: [
+          {
+            wantFns: ['doBulk'],
+            wantMetricsDelta: {
+              lockAcquires: 2,
+              lockReleases: 2,
+              writes: 2,
+              writesToDb: 2,
+            },
+            cbArgs: [[new Error('injected doBulk error')]],
+          },
+          {
+            wantFns: ['set', 'set'],
+            wantMetricsDelta: {
+              writesToDbRetried: 2,
+            },
+            cbArgs: [[new Error('test1')], [new Error('test2')]],
+          },
+        ],
+        wantErr: (err) => ['test1', 'test2'].includes(err.message),
         wantMetricsDelta: {
           writesFailed: 2,
           writesFinished: 2,
@@ -497,7 +562,7 @@ describe(__filename, function () {
         action: async () => await Promise.all([db.set(key, 'v'), db.set(key, 'v2')]),
         wantOps: [
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockAcquires: 2,
               lockAwaits: 1,
@@ -506,7 +571,7 @@ describe(__filename, function () {
               writesObsoleted: 1,
               writesToDb: 1,
             },
-            cbArgs: [null],
+            cbArgs: [[null]],
           },
         ],
         wantErr: null,
@@ -520,7 +585,7 @@ describe(__filename, function () {
         action: async () => await Promise.all([db.set(key, 'v'), db.set(key, 'v2')]),
         wantOps: [
           {
-            wantFn: 'set',
+            wantFns: ['set'],
             wantMetricsDelta: {
               lockAcquires: 2,
               lockAwaits: 1,
@@ -529,7 +594,7 @@ describe(__filename, function () {
               writesObsoleted: 1,
               writesToDb: 1,
             },
-            cbArgs: [new Error('test')],
+            cbArgs: [[new Error('test')]],
           },
         ],
         wantErr: {message: 'test'},
@@ -544,27 +609,49 @@ describe(__filename, function () {
 
     for (const tc of tcs) {
       it(tc.name, async function () {
-        let opStart;
+        const opStarts = [];
         for (const fn of ['doBulk', 'get', 'remove', 'set']) {
           mock.on(fn, (...args) => {
+            const opStart = opStarts.shift();
             const cb = args.pop();
             opStart.open([fn, cb]);
           });
         }
         let before = {...db.metrics};
         let actionDone;
-        // advance() triggers the next database operation, either by starting tc.action (if
-        // tc.action has not yet been started) or completing the previous operation (if tc.action
+        // advance() triggers the next database operation(s), either by starting tc.action (if
+        // tc.action has not yet been started) or completing the previous operation(s) (if tc.action
         // has been started).
         let advance = () => { actionDone = tc.action(); };
-        for (const op of tc.wantOps) {
-          opStart = new Gate();
-          advance();
-          const [gotFn, cb] = await opStart;
-          assert.equal(gotFn, op.wantFn);
-          assertMetricsDelta(before, db.metrics, op.wantMetricsDelta);
+        for (const ops of tc.wantOps) {
+          // Provide a way for the mock database to tell us that a mocked database method has been
+          // called. The number of expected parallel operations for this iteration is
+          // ops.wantFns.length, so that is the number of Gates that are added to opStarts. Each
+          // Gate resolves to [fn, cb] where fn is the name of the mocked database method and cb is
+          // the mocked database method's callback.
+          for (let i = 0; i < ops.wantFns.length; ++i) opStarts.push(new Gate());
+
+          // Trigger the call(s) to the mock database method(s). This is scheduled to run in the
+          // future to ensure that advance() does not empty the opStarts array until after the
+          // Promise.all() call below has a chance to see all of the Promises in opStarts.
+          setImmediate(advance);
+
+          // Wait until the expected number of parallel database method calls have started.
+          const gotOps = await Promise.all(opStarts);
+
+          assertMetricsDelta(before, db.metrics, ops.wantMetricsDelta);
           before = {...db.metrics};
-          advance = () => cb(...op.cbArgs);
+
+          const advanceFns = [];
+          for (const [gotFn, cb] of gotOps) {
+            const i = ops.wantFns.indexOf(gotFn);
+            assert(i >= 0, `unexpected mock database method call: ${gotFn}`);
+            ops.wantFns.splice(i, 1);
+            const [cbArgs] = ops.cbArgs.splice(i, 1);
+            advanceFns.push(() => cb(...cbArgs));
+          }
+          assert.equal(ops.wantFns.length, 0, `missing call(s): ${ops.wantFns.join(', ')}`);
+          advance = () => advanceFns.forEach((f) => f());
         }
         advance();
         await (tc.wantErr ? assert.rejects(actionDone, tc.wantErr) : actionDone);

--- a/test/test_metrics.js
+++ b/test/test_metrics.js
@@ -250,7 +250,7 @@ describe(__filename, function () {
         },
       },
       {
-        name: 'set error',
+        name: 'set db error',
         action: async () => await db.set(key, 'v'),
         wantOps: [
           {
@@ -270,6 +270,19 @@ describe(__filename, function () {
           writesFinished: 1,
           writesToDbFailed: 1,
           writesToDbFinished: 1,
+        },
+      },
+      {
+        name: 'set json error',
+        action: async () => await db.set(key, BigInt(1)), // BigInts are not JSONable.
+        wantOps: [],
+        wantErr: {name: 'TypeError'},
+        wantMetricsDelta: {
+          lockAcquires: 1,
+          lockReleases: 1,
+          writes: 1,
+          writesFailed: 1,
+          writesFinished: 1,
         },
       },
       {
@@ -304,7 +317,7 @@ describe(__filename, function () {
         },
       },
       {
-        name: 'setSub error',
+        name: 'setSub db write error',
         action: async () => await db.setSub(key, ['s'], 'v2'),
         wantOps: [
           {
@@ -334,6 +347,105 @@ describe(__filename, function () {
           writesFinished: 1,
           writesToDbFailed: 1,
           writesToDbFinished: 1,
+        },
+      },
+      {
+        name: 'setSub db read error',
+        action: async () => await db.setSub(key, ['s'], 'v2'),
+        wantOps: [
+          {
+            wantFn: 'get',
+            wantMetricsDelta: {
+              lockAcquires: 1,
+              reads: 1,
+              readsFromDb: 1,
+            },
+            cbArgs: [new Error('test')],
+          },
+        ],
+        wantErr: {message: 'test'},
+        wantMetricsDelta: {
+          lockReleases: 1,
+          readsFailed: 1,
+          readsFinished: 1,
+          readsFromDbFailed: 1,
+          readsFromDbFinished: 1,
+          writes: 1,
+          writesFailed: 1,
+          writesFinished: 1,
+        },
+      },
+      {
+        name: 'setSub json read error',
+        action: async () => await db.setSub(key, ['s'], 'v2'),
+        wantOps: [
+          {
+            wantFn: 'get',
+            wantMetricsDelta: {
+              lockAcquires: 1,
+              reads: 1,
+              readsFromDb: 1,
+            },
+            cbArgs: [null, 'ignore me -- this is intentionally invalid json'],
+          },
+        ],
+        wantErr: {name: 'SyntaxError'},
+        wantMetricsDelta: {
+          lockReleases: 1,
+          readsFailed: 1,
+          readsFinished: 1,
+          readsFromDbFinished: 1,
+          writes: 1,
+          writesFailed: 1,
+          writesFinished: 1,
+        },
+      },
+      {
+        name: 'setSub update non-object error',
+        action: async () => await db.setSub(key, ['s'], 'v2'),
+        wantOps: [
+          {
+            wantFn: 'get',
+            wantMetricsDelta: {
+              lockAcquires: 1,
+              reads: 1,
+              readsFromDb: 1,
+            },
+            cbArgs: [null, '"foo"'],
+          },
+        ],
+        wantErr: {message: /non-object/},
+        wantMetricsDelta: {
+          lockReleases: 1,
+          readsFinished: 1,
+          readsFromDbFinished: 1,
+          writes: 1,
+          writesFailed: 1,
+          writesFinished: 1,
+        },
+      },
+      {
+        name: 'setSub json write error',
+        action: async () => await db.setSub(key, ['s'], BigInt(1)), // BigInts are not JSONable.
+        wantOps: [
+          {
+            wantFn: 'get',
+            wantMetricsDelta: {
+              lockAcquires: 1,
+              reads: 1,
+              readsFromDb: 1,
+            },
+            cbArgs: [null, '{"s": "v1"}'],
+          },
+        ],
+        wantErr: {name: 'TypeError'},
+        wantMetricsDelta: {
+          lockReleases: 1,
+          readsFinished: 1,
+          readsFromDbFinished: 1,
+          writes: 1,
+          writesFailed: 1,
+          writesFinished: 1,
         },
       },
       {


### PR DESCRIPTION
Multiple commits:
* cache: Use the logger object when logging errors
* mock: Decrease `writeInterval` to speed up tests
* tests: Redo write metric tests for readability, flexibility
* cache: Also increment write metrics if `setSub()` read fails
* cache: Retry bulk write operations individually

cc @packardone