### PR TITLE
Use ES6 class hierarchy for database classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,22 +313,18 @@ environment variable `NODE_TLS_REJECT_UNAUTHORIZED = 0` and add the flag
 
 ## How to add support for another database
 
-1. Add your database to `packages.json`, this will happen automatically if you
-   run `npm install %yourdatabase%`
-1. Add some example settings to `test/lib/databases.js` for your database.
-1. Look at `databases/mysql_db.js`, your module have to provide the same
-   functions. Call it `DATABASENAME_db.js` and reimplement the functions for
-   your database. Most of your work here will be copy/paste from other databases
-   so don't be scared.
-1. Add your database Travis setup steps to `.travis.yml`, see the
-   `before_install` section and MySQL example. Note that MySQL has a preloaded
-   script (comes from mysql.sql) which preloads the database with 1M records. If
-   you can, you should do the same.
-1. Run `npm test` and ensure it's working.
-1. Branch from master `git checkout -b my-awesome-database` and submit a pull
-   request including the changes which should include **1 new and 3 modified
-   files**.
-1. Once merged we really need you to be on top of maintaining your code.
+1. Add the database driver to `packages.json`, this will happen automatically if
+   you run `npm install %yourdatabase%`
+1. Create `databases/DATABASENAME_db.js` and have it export a `Database` class
+   that derives from `lib/AbstractDatabase.js`. Implement the required
+   functions.
+1. Add a service for the database to the test job in
+   `.github/workflows/npmpublish.yml`.
+1. Add an entry to `test/lib/databases.js` for your database and configure it to
+   work with the service added to the GitHub workflow.
+1. Install and start the database server and configure it to work with the
+   settings in your `test/lib/databases.js` entry.
+1. Run `npm test` to ensure that it works.
 
 ## License
 

--- a/databases/cassandra_db.js
+++ b/databases/cassandra_db.js
@@ -15,233 +15,234 @@
 
 const cassandra = require('cassandra-driver');
 
-/**
- * Cassandra DB constructor.
- *
- * @param {Object} settings The required settings object to initiate the Cassandra database
- * @param {String[]} settings.clientOptions See
- *     http://www.datastax.com/drivers/nodejs/2.0/global.html#ClientOptions for a full set of
- *     options that can be used
- * @param {String} settings.columnFamily The column family that should be used to store data. The
- *     column family will be created if it doesn't exist
- * @param {Function} [settings.logger] Function that will be used to pass on log events emitted by
- *     the Cassandra driver. See https://github.com/datastax/nodejs-driver#logging for more
- *     information
- */
-exports.Database = function (settings) {
-  if (!settings.clientOptions) {
-    throw new Error('The Cassandra client options should be defined');
-  }
-  if (!settings.columnFamily) {
-    throw new Error('The Cassandra column family should be defined');
-  }
+exports.Database = class {
+  /**
+   * @param {Object} settings The required settings object to initiate the Cassandra database
+   * @param {String[]} settings.clientOptions See
+   *     http://www.datastax.com/drivers/nodejs/2.0/global.html#ClientOptions for a full set of
+   *     options that can be used
+   * @param {String} settings.columnFamily The column family that should be used to store data. The
+   *     column family will be created if it doesn't exist
+   * @param {Function} [settings.logger] Function that will be used to pass on log events emitted by
+   *     the Cassandra driver. See https://github.com/datastax/nodejs-driver#logging for more
+   *     information
+   */
+  constructor(settings) {
+    if (!settings.clientOptions) {
+      throw new Error('The Cassandra client options should be defined');
+    }
+    if (!settings.columnFamily) {
+      throw new Error('The Cassandra column family should be defined');
+    }
 
-  this.settings = {};
-  this.settings.clientOptions = settings.clientOptions;
-  this.settings.columnFamily = settings.columnFamily;
-  this.settings.logger = settings.logger;
-};
-
-/**
- * Initializes the Cassandra client, connects to Cassandra and creates the CF if it didn't exist
- * already
- *
- * @param  {Function}   callback        Standard callback method.
- * @param  {Error}      callback.err    An error object (if any.)
- */
-exports.Database.prototype.init = function (callback) {
-  // Create a client
-  this.client = new cassandra.Client(this.settings.clientOptions);
-
-  // Pass on log messages if a logger has been configured
-  if (this.settings.logger) {
-    this.client.on('log', this.settings.logger);
+    this.settings = {};
+    this.settings.clientOptions = settings.clientOptions;
+    this.settings.columnFamily = settings.columnFamily;
+    this.settings.logger = settings.logger;
   }
 
-  // Check whether our column family already exists and create it if necessary
-  this.client.execute(
-      'SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?',
-      [this.settings.clientOptions.keyspace],
-      (err, result) => {
-        if (err) {
-          return callback(err);
-        }
+  /**
+   * Initializes the Cassandra client, connects to Cassandra and creates the CF if it didn't exist
+   * already
+   *
+   * @param  {Function}   callback        Standard callback method.
+   * @param  {Error}      callback.err    An error object (if any.)
+   */
+  init(callback) {
+    // Create a client
+    this.client = new cassandra.Client(this.settings.clientOptions);
 
-        let isDefined = false;
-        const length = result.rows.length;
-        for (let i = 0; i < length; i++) {
-          if (result.rows[i].columnfamily_name === this.settings.columnFamily) {
-            isDefined = true;
-            break;
+    // Pass on log messages if a logger has been configured
+    if (this.settings.logger) {
+      this.client.on('log', this.settings.logger);
+    }
+
+    // Check whether our column family already exists and create it if necessary
+    this.client.execute(
+        'SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?',
+        [this.settings.clientOptions.keyspace],
+        (err, result) => {
+          if (err) {
+            return callback(err);
           }
-        }
 
-        if (isDefined) {
-          return callback(null);
-        } else {
-          const cql =
-              `CREATE COLUMNFAMILY "${this.settings.columnFamily}" ` +
-              '(key text PRIMARY KEY, data text)';
-          this.client.execute(cql, callback);
-        }
-      });
-};
+          let isDefined = false;
+          const length = result.rows.length;
+          for (let i = 0; i < length; i++) {
+            if (result.rows[i].columnfamily_name === this.settings.columnFamily) {
+              isDefined = true;
+              break;
+            }
+          }
 
+          if (isDefined) {
+            return callback(null);
+          } else {
+            const cql =
+                `CREATE COLUMNFAMILY "${this.settings.columnFamily}" ` +
+                '(key text PRIMARY KEY, data text)';
+            this.client.execute(cql, callback);
+          }
+        });
+  }
 
-/**
- * Gets a value from Cassandra
- *
- * @param  {String}     key               The key for which the value should be retrieved
- * @param  {Function}   callback          Standard callback method
- * @param  {Error}      callback.err      An error object, if any
- * @param  {String}     callback.value    The value for the given key (if any)
- */
-exports.Database.prototype.get = function (key, callback) {
-  const cql = `SELECT data FROM "${this.settings.columnFamily}" WHERE key = ?`;
-  this.client.execute(cql, [key], (err, result) => {
-    if (err) {
-      return callback(err);
-    }
-
-    if (!result.rows || result.rows.length === 0) {
-      return callback(null, null);
-    }
-
-    return callback(null, result.rows[0].data);
-  });
-};
-
-/**
- * Cassandra has no native `findKeys` method. This function implements a naive filter by retrieving
- * *all* the keys and filtering those. This should obviously be used with the utmost care and is
- * probably not something you want to run in production.
- *
- * @param  {String}     key               The filter for keys that should match
- * @param  {String}     [notKey]          The filter for keys that shouldn't match
- * @param  {Function}   callback          Standard callback method
- * @param  {Error}      callback.err      An error object, if any
- * @param  {String[]}   callback.keys     An array of keys that match the specified filters
- */
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  let cql = null;
-  if (!notKey) {
-    // Get all the keys
-    cql = `SELECT key FROM "${this.settings.columnFamily}"`;
-    this.client.execute(cql, (err, result) => {
+  /**
+   * Gets a value from Cassandra
+   *
+   * @param  {String}     key               The key for which the value should be retrieved
+   * @param  {Function}   callback          Standard callback method
+   * @param  {Error}      callback.err      An error object, if any
+   * @param  {String}     callback.value    The value for the given key (if any)
+   */
+  get(key, callback) {
+    const cql = `SELECT data FROM "${this.settings.columnFamily}" WHERE key = ?`;
+    this.client.execute(cql, [key], (err, result) => {
       if (err) {
         return callback(err);
       }
 
-      // Construct a regular expression based on the given key
-      const regex = new RegExp(`^${key.replace(/\*/g, '.*')}$`);
+      if (!result.rows || result.rows.length === 0) {
+        return callback(null, null);
+      }
 
-      const keys = [];
-      result.rows.forEach((row) => {
-        if (regex.test(row.key)) {
-          keys.push(row.key);
-        }
-      });
-
-      return callback(null, keys);
+      return callback(null, result.rows[0].data);
     });
-  } else if (notKey === '*:*:*') {
-    // restrict key to format 'text:*'
-    const matches = /^([^:]+):\*$/.exec(key);
-    if (matches) {
-      // Get the 'text' bit out of the key and get all those keys from a special column.
-      // We can retrieve them from this column as we're duplicating them on .set/.remove
-      cql = `SELECT * from "${this.settings.columnFamily}" WHERE key = ?`;
-      this.client.execute(cql, [`ueberdb:keys:${matches[1]}`], (err, result) => {
+  }
+
+  /**
+   * Cassandra has no native `findKeys` method. This function implements a naive filter by
+   * retrieving *all* the keys and filtering those. This should obviously be used with the utmost
+   * care and is probably not something you want to run in production.
+   *
+   * @param  {String}     key               The filter for keys that should match
+   * @param  {String}     [notKey]          The filter for keys that shouldn't match
+   * @param  {Function}   callback          Standard callback method
+   * @param  {Error}      callback.err      An error object, if any
+   * @param  {String[]}   callback.keys     An array of keys that match the specified filters
+   */
+  findKeys(key, notKey, callback) {
+    let cql = null;
+    if (!notKey) {
+      // Get all the keys
+      cql = `SELECT key FROM "${this.settings.columnFamily}"`;
+      this.client.execute(cql, (err, result) => {
         if (err) {
           return callback(err);
         }
 
-        if (!result.rows || result.rows.length === 0) {
-          return callback(null, []);
-        }
+        // Construct a regular expression based on the given key
+        const regex = new RegExp(`^${key.replace(/\*/g, '.*')}$`);
 
-        const keys = result.rows.map((row) => row.data);
+        const keys = [];
+        result.rows.forEach((row) => {
+          if (regex.test(row.key)) {
+            keys.push(row.key);
+          }
+        });
+
         return callback(null, keys);
       });
-    } else {
-      const msg = 'Cassandra db only supports key patterns like pad:* when notKey is set to *:*:*';
-      return callback(new Error(msg), null);
-    }
-  } else {
-    return callback(new Error('Cassandra db currently only supports *:*:* as notKey'), null);
-  }
-};
-
-/**
- * Sets a value for a key
- *
- * @param  {String}     key             The key to set
- * @param  {String}     value           The value associated to this key
- * @param  {Function}   callback        Standard callback method
- * @param  {Error}      callback.err    An error object, if any
- */
-exports.Database.prototype.set = function (key, value, callback) {
-  this.doBulk([{type: 'set', key, value}], callback);
-};
-
-/**
- * Removes a key and it's value from the column family
- *
- * @param  {String}     key             The key to remove
- * @param  {Function}   callback        Standard callback method
- * @param  {Error}      callback.err    An error object, if any
- */
-exports.Database.prototype.remove = function (key, callback) {
-  this.doBulk([{type: 'remove', key}], callback);
-};
-
-/**
- * Performs multiple operations in one action
- *
- * @param  {Object[]}   bulk            The set of operations that should be performed
- * @param  {Function}   callback        Standard callback method
- * @param  {Error}      callback.err    An error object, if any
- */
-exports.Database.prototype.doBulk = function (bulk, callback) {
-  const queries = [];
-  bulk.forEach((operation) => {
-    // We support finding keys of the form `test:*`. If anything matches, we will try and save this
-    const matches = /^([^:]+):([^:]+)$/.exec(operation.key);
-    if (operation.type === 'set') {
-      queries.push({
-        query: `UPDATE "${this.settings.columnFamily}" SET data = ? WHERE key = ?`,
-        params: [operation.value, operation.key],
-      });
-
+    } else if (notKey === '*:*:*') {
+      // restrict key to format 'text:*'
+      const matches = /^([^:]+):\*$/.exec(key);
       if (matches) {
+        // Get the 'text' bit out of the key and get all those keys from a special column.
+        // We can retrieve them from this column as we're duplicating them on .set/.remove
+        cql = `SELECT * from "${this.settings.columnFamily}" WHERE key = ?`;
+        this.client.execute(cql, [`ueberdb:keys:${matches[1]}`], (err, result) => {
+          if (err) {
+            return callback(err);
+          }
+
+          if (!result.rows || result.rows.length === 0) {
+            return callback(null, []);
+          }
+
+          const keys = result.rows.map((row) => row.data);
+          return callback(null, keys);
+        });
+      } else {
+        const msg =
+            'Cassandra db only supports key patterns like pad:* when notKey is set to *:*:*';
+        return callback(new Error(msg), null);
+      }
+    } else {
+      return callback(new Error('Cassandra db currently only supports *:*:* as notKey'), null);
+    }
+  }
+
+  /**
+   * Sets a value for a key
+   *
+   * @param  {String}     key             The key to set
+   * @param  {String}     value           The value associated to this key
+   * @param  {Function}   callback        Standard callback method
+   * @param  {Error}      callback.err    An error object, if any
+   */
+  set(key, value, callback) {
+    this.doBulk([{type: 'set', key, value}], callback);
+  }
+
+  /**
+   * Removes a key and it's value from the column family
+   *
+   * @param  {String}     key             The key to remove
+   * @param  {Function}   callback        Standard callback method
+   * @param  {Error}      callback.err    An error object, if any
+   */
+  remove(key, callback) {
+    this.doBulk([{type: 'remove', key}], callback);
+  }
+
+  /**
+   * Performs multiple operations in one action
+   *
+   * @param  {Object[]}   bulk            The set of operations that should be performed
+   * @param  {Function}   callback        Standard callback method
+   * @param  {Error}      callback.err    An error object, if any
+   */
+  doBulk(bulk, callback) {
+    const queries = [];
+    bulk.forEach((operation) => {
+      // We support finding keys of the form `test:*`. If anything matches, we will try and save
+      // this
+      const matches = /^([^:]+):([^:]+)$/.exec(operation.key);
+      if (operation.type === 'set') {
         queries.push({
           query: `UPDATE "${this.settings.columnFamily}" SET data = ? WHERE key = ?`,
-          params: ['1', `ueberdb:keys:${matches[1]}`],
+          params: [operation.value, operation.key],
         });
-      }
-    } else if (operation.type === 'remove') {
-      queries.push({
-        query: `DELETE FROM "${this.settings.columnFamily}" WHERE key=?`,
-        params: [operation.key],
-      });
 
-      if (matches) {
+        if (matches) {
+          queries.push({
+            query: `UPDATE "${this.settings.columnFamily}" SET data = ? WHERE key = ?`,
+            params: ['1', `ueberdb:keys:${matches[1]}`],
+          });
+        }
+      } else if (operation.type === 'remove') {
         queries.push({
-          query: `DELETE FROM "${this.settings.columnFamily}" WHERE key = ?`,
-          params: [`ueberdb:keys:${matches[1]}`],
+          query: `DELETE FROM "${this.settings.columnFamily}" WHERE key=?`,
+          params: [operation.key],
         });
-      }
-    }
-  });
-  this.client.batch(queries, {prepare: true}, callback);
-};
 
-/**
- * Closes the Cassandra connection
- *
- * @param  {Function}   callback        Standard callback method
- * @param  {Error}      callback.err    Error object in case something goes wrong
- */
-exports.Database.prototype.close = function (callback) {
-  this.pool.shutdown(callback);
+        if (matches) {
+          queries.push({
+            query: `DELETE FROM "${this.settings.columnFamily}" WHERE key = ?`,
+            params: [`ueberdb:keys:${matches[1]}`],
+          });
+        }
+      }
+    });
+    this.client.batch(queries, {prepare: true}, callback);
+  }
+
+  /**
+   * Closes the Cassandra connection
+   *
+   * @param  {Function}   callback        Standard callback method
+   * @param  {Error}      callback.err    Error object in case something goes wrong
+   */
+  close(callback) {
+    this.pool.shutdown(callback);
+  }
 };

--- a/databases/cassandra_db.js
+++ b/databases/cassandra_db.js
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const cassandra = require('cassandra-driver');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   /**
    * @param {Object} settings The required settings object to initiate the Cassandra database
    * @param {String[]} settings.clientOptions See
@@ -28,6 +29,7 @@ exports.Database = class {
    *     information
    */
   constructor(settings) {
+    super();
     if (!settings.clientOptions) {
       throw new Error('The Cassandra client options should be defined');
     }

--- a/databases/couch_db.js
+++ b/databases/couch_db.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const nano = require('nano');
 const async = require('async');
 
@@ -25,8 +26,9 @@ const handleError = (er) => {
   if (er) throw new Error(er);
 };
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.db = null;
     this.client = null;
     this.settings = settings;

--- a/databases/dirty_db.js
+++ b/databases/dirty_db.js
@@ -22,10 +22,12 @@
 *
 */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const Dirty = require('dirty');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.db = null;
 
     if (!settings || !settings.filename) {

--- a/databases/dirty_git_db.js
+++ b/databases/dirty_git_db.js
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const Dirty = require('dirty');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.db = null;
 
     if (!settings || !settings.filename) {

--- a/databases/dirty_git_db.js
+++ b/databases/dirty_git_db.js
@@ -17,58 +17,60 @@
 
 const Dirty = require('dirty');
 
-exports.Database = function (settings) {
-  this.db = null;
+exports.Database = class {
+  constructor(settings) {
+    this.db = null;
 
-  if (!settings || !settings.filename) {
-    settings = {filename: null};
+    if (!settings || !settings.filename) {
+      settings = {filename: null};
+    }
+
+    this.settings = settings;
+
+    // set default settings
+    this.settings.cache = 0;
+    this.settings.writeInterval = 0;
+    this.settings.json = false;
   }
 
-  this.settings = settings;
+  init(callback) {
+    this.db = new Dirty(this.settings.filename);
+    this.db.on('load', (err) => {
+      callback();
+    });
+  }
 
-  // set default settings
-  this.settings.cache = 0;
-  this.settings.writeInterval = 0;
-  this.settings.json = false;
-};
+  get(key, callback) {
+    callback(null, this.db.get(key));
+  }
 
-exports.Database.prototype.init = function (callback) {
-  this.db = new Dirty(this.settings.filename);
-  this.db.on('load', (err) => {
-    callback();
-  });
-};
+  findKeys(key, notKey, callback) {
+    const keys = [];
+    const regex = this.createFindRegex(key, notKey);
+    this.db.forEach((key, val) => {
+      if (key.search(regex) !== -1) {
+        keys.push(key);
+      }
+    });
+    callback(null, keys);
+  }
 
-exports.Database.prototype.get = function (key, callback) {
-  callback(null, this.db.get(key));
-};
+  set(key, value, callback) {
+    this.db.set(key, value, callback);
+    const databasePath = require('path').dirname(this.settings.filename);
+    require('simple-git')(databasePath)
+        .silent(true)
+        .add('./*.db')
+        .commit('Automated commit...')
+        .push(['-u', 'origin', 'master'], () => console.debug('Stored git commit'));
+  }
 
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  const keys = [];
-  const regex = this.createFindRegex(key, notKey);
-  this.db.forEach((key, val) => {
-    if (key.search(regex) !== -1) {
-      keys.push(key);
-    }
-  });
-  callback(null, keys);
-};
+  remove(key, callback) {
+    this.db.rm(key, callback);
+  }
 
-exports.Database.prototype.set = function (key, value, callback) {
-  this.db.set(key, value, callback);
-  const databasePath = require('path').dirname(this.settings.filename);
-  require('simple-git')(databasePath)
-      .silent(true)
-      .add('./*.db')
-      .commit('Automated commit...')
-      .push(['-u', 'origin', 'master'], () => console.debug('Stored git commit'));
-};
-
-exports.Database.prototype.remove = function (key, callback) {
-  this.db.rm(key, callback);
-};
-
-exports.Database.prototype.close = function (callback) {
-  this.db.close();
-  if (callback) callback();
+  close(callback) {
+    this.db.close();
+    if (callback) callback();
+  }
 };

--- a/databases/elasticsearch_db.js
+++ b/databases/elasticsearch_db.js
@@ -30,194 +30,196 @@ const elasticsearchSettings = {
 
 let client;
 
-exports.Database = function (settings) {
-  this.db = null;
+exports.Database = class {
+  constructor(settings) {
+    this.db = null;
 
-  this.settings = settings || {};
+    this.settings = settings || {};
 
-  // update settings if they were provided
-  if (this.settings.host) {
-    elasticsearchSettings.hostname = this.settings.host;
-  }
-
-  if (this.settings.port) {
-    elasticsearchSettings.port = this.settings.port;
-  }
-
-  if (this.settings.base_index) {
-    elasticsearchSettings.base_index = this.settings.base_index;
-  }
-
-  if (this.settings.api) {
-    elasticsearchSettings.api = this.settings.api;
-  }
-};
-
-/**
- * Initialize the elasticsearch client, then ping the server to ensure that a
- * connection was made.
- */
-exports.Database.prototype.init = function (callback) {
-  // create elasticsearch client
-  client = new es.Client({
-    host: `${elasticsearchSettings.hostname}:${elasticsearchSettings.port}`,
-    apiVersion: elasticsearchSettings.api,
-    // log: "trace" // useful for debugging
-  });
-
-  // test the connection
-  client.ping({
-    requestTimeout: 3000,
-  }, (error) => {
-    if (error) {
-      console.error('unable to communicate with elasticsearch');
+    // update settings if they were provided
+    if (this.settings.host) {
+      elasticsearchSettings.hostname = this.settings.host;
     }
 
-    callback(error);
-  });
-};
-
-/**
- *  This function provides read functionality to the database.
- *
- *  @param {String} key Key, of the format "test:test1" or, optionally, of the
- *    format "test:test1:check:check1"
- *  @param {function} callback Function will be called in the event of an error or
- *    upon completion of a successful database retrieval.
- */
-exports.Database.prototype.get = function (key, callback) {
-  client.get(getIndexTypeId(key), (error, response) => {
-    parseResponse(error, response, callback);
-  });
-};
-
-/**
- *  The three key scenarios for this are:
- *      (test:test1, null) ; (test:*, *:*:*) ; (test:*, null)
- *
- *  TODO This currently works only for the second implementation above.
- *
- *  For more information:
- *    - See the #Limitations section of the ueberDB README.
- *    - See https://github.com/Pita/ueberDB/wiki/findKeys-functionality, as well
- *      as the sqlite and mysql implementations.
- *
- *  @param key Search key, which uses an asterisk (*) as the wild card.
- *  @param notKey Used to filter the result set
- *  @param callback First param is error, second is result
- */
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  const splitKey = key.split(':');
-
-  client.search({
-    index: elasticsearchSettings.base_index,
-    type: splitKey[0],
-    size: 100, // this is a pretty random threshold...
-  }, (error, response) => {
-    if (error) {
-      console.error('findkeys', error);
-      callback(error);
-      return;
+    if (this.settings.port) {
+      elasticsearchSettings.port = this.settings.port;
     }
 
-    if (!error && response.hits) {
-      const keys = [];
-      for (let counter = 0; counter < response.hits.total; counter++) {
-        keys.push(`${splitKey[0]}:${response.hits.hits[counter]._id}`);
+    if (this.settings.base_index) {
+      elasticsearchSettings.base_index = this.settings.base_index;
+    }
+
+    if (this.settings.api) {
+      elasticsearchSettings.api = this.settings.api;
+    }
+  }
+
+  /**
+   * Initialize the elasticsearch client, then ping the server to ensure that a
+   * connection was made.
+   */
+  init(callback) {
+    // create elasticsearch client
+    client = new es.Client({
+      host: `${elasticsearchSettings.hostname}:${elasticsearchSettings.port}`,
+      apiVersion: elasticsearchSettings.api,
+      // log: "trace" // useful for debugging
+    });
+
+    // test the connection
+    client.ping({
+      requestTimeout: 3000,
+    }, (error) => {
+      if (error) {
+        console.error('unable to communicate with elasticsearch');
       }
-      callback(null, keys);
-    }
-  });
-};
 
-/**
- *  This function provides write functionality to the database.
- *
- *  @param {String} key Key, of the format "test:test1" or, optionally, of the
- *    format "test:test1:check:check1"
- *  @param {JSON|String} value The value to be stored to the database.  The value is
- *    always converted to {val:value} before being written to the database, to account
- *    for situations where the value is just a string.
- *  @param {function} callback Function will be called in the event of an error or on
- *    completion of a successful database write.
- */
-exports.Database.prototype.set = function (key, value, callback) {
-  const options = getIndexTypeId(key);
+      callback(error);
+    });
+  }
 
-  options.body = {
-    val: value,
-  };
+  /**
+   *  This function provides read functionality to the database.
+   *
+   *  @param {String} key Key, of the format "test:test1" or, optionally, of the
+   *    format "test:test1:check:check1"
+   *  @param {function} callback Function will be called in the event of an error or
+   *    upon completion of a successful database retrieval.
+   */
+  get(key, callback) {
+    client.get(getIndexTypeId(key), (error, response) => {
+      parseResponse(error, response, callback);
+    });
+  }
 
-  client.index(options, (error, response) => {
-    parseResponse(error, response, callback);
-  });
-};
+  /**
+   *  The three key scenarios for this are:
+   *      (test:test1, null) ; (test:*, *:*:*) ; (test:*, null)
+   *
+   *  TODO This currently works only for the second implementation above.
+   *
+   *  For more information:
+   *    - See the #Limitations section of the ueberDB README.
+   *    - See https://github.com/Pita/ueberDB/wiki/findKeys-functionality, as well
+   *      as the sqlite and mysql implementations.
+   *
+   *  @param key Search key, which uses an asterisk (*) as the wild card.
+   *  @param notKey Used to filter the result set
+   *  @param callback First param is error, second is result
+   */
+  findKeys(key, notKey, callback) {
+    const splitKey = key.split(':');
 
-/**
- *  This function provides delete functionality to the database.
- *
- *  The index, type, and ID will be parsed from the key, and this document will
- *  be deleted from the database.
- *
- *  @param {String} key Key, of the format "test:test1" or, optionally, of the
- *    format "test:test1:check:check1"
- *  @param {function} callback Function will be called in the event of an error or on
- *    completion of a successful database write.
- */
-exports.Database.prototype.remove = function (key, callback) {
-  client.delete(key, (error, response) => {
-    parseResponse(error, response, callback);
-  });
-};
+    client.search({
+      index: elasticsearchSettings.base_index,
+      type: splitKey[0],
+      size: 100, // this is a pretty random threshold...
+    }, (error, response) => {
+      if (error) {
+        console.error('findkeys', error);
+        callback(error);
+        return;
+      }
 
-/**
- *  This uses the bulk upload functionality of elasticsearch (url:port/_bulk).
- *
- *  The CacheAndBufferLayer will periodically (every this.settings.writeInterval)
- *  flush writes that have already been done in the local cache out to the database.
- *
- *  @param {Array} bulk An array of JSON data in the format:
- *      {"type":type, "key":key, "value":value}
- *  @param {function} callback This function will be called on an error or upon the
- *      successful completion of the database write.
- */
-exports.Database.prototype.doBulk = function (bulk, callback) {
-  // bulk is an array of JSON:
-  // example: [{"type":"set", "key":"sessionstorage:{id}", "value":{"cookie":{...}}]
+      if (!error && response.hits) {
+        const keys = [];
+        for (let counter = 0; counter < response.hits.total; counter++) {
+          keys.push(`${splitKey[0]}:${response.hits.hits[counter]._id}`);
+        }
+        callback(null, keys);
+      }
+    });
+  }
 
-  const operations = [];
+  /**
+   *  This function provides write functionality to the database.
+   *
+   *  @param {String} key Key, of the format "test:test1" or, optionally, of the
+   *    format "test:test1:check:check1"
+   *  @param {JSON|String} value The value to be stored to the database.  The value is
+   *    always converted to {val:value} before being written to the database, to account
+   *    for situations where the value is just a string.
+   *  @param {function} callback Function will be called in the event of an error or on
+   *    completion of a successful database write.
+   */
+  set(key, value, callback) {
+    const options = getIndexTypeId(key);
 
-  for (let counter = 0; counter < bulk.length; counter++) {
-    const indexTypeId = getIndexTypeId(bulk[counter].key);
-    const operationPayload = {
-      _index: indexTypeId.index,
-      _type: indexTypeId.type,
-      _id: indexTypeId.id,
+    options.body = {
+      val: value,
     };
 
-    switch (bulk[counter].type) {
-      case 'set':
-        operations.push({index: operationPayload});
-        operations.push({val: JSON.parse(bulk[counter].value)});
-        break;
-      case 'remove':
-        operations.push({delete: operationPayload});
-        break;
-      default:
-        continue;
-    }
+    client.index(options, (error, response) => {
+      parseResponse(error, response, callback);
+    });
   }
 
-  // send bulk request
-  client.bulk({
-    body: operations,
-  }, (error, response) => {
-    parseResponse(error, response, callback);
-  });
-};
+  /**
+   *  This function provides delete functionality to the database.
+   *
+   *  The index, type, and ID will be parsed from the key, and this document will
+   *  be deleted from the database.
+   *
+   *  @param {String} key Key, of the format "test:test1" or, optionally, of the
+   *    format "test:test1:check:check1"
+   *  @param {function} callback Function will be called in the event of an error or on
+   *    completion of a successful database write.
+   */
+  remove(key, callback) {
+    client.delete(key, (error, response) => {
+      parseResponse(error, response, callback);
+    });
+  }
 
-exports.Database.prototype.close = function (callback) {
-  callback(null);
+  /**
+   *  This uses the bulk upload functionality of elasticsearch (url:port/_bulk).
+   *
+   *  The CacheAndBufferLayer will periodically (every this.settings.writeInterval)
+   *  flush writes that have already been done in the local cache out to the database.
+   *
+   *  @param {Array} bulk An array of JSON data in the format:
+   *      {"type":type, "key":key, "value":value}
+   *  @param {function} callback This function will be called on an error or upon the
+   *      successful completion of the database write.
+   */
+  doBulk(bulk, callback) {
+    // bulk is an array of JSON:
+    // example: [{"type":"set", "key":"sessionstorage:{id}", "value":{"cookie":{...}}]
+
+    const operations = [];
+
+    for (let counter = 0; counter < bulk.length; counter++) {
+      const indexTypeId = getIndexTypeId(bulk[counter].key);
+      const operationPayload = {
+        _index: indexTypeId.index,
+        _type: indexTypeId.type,
+        _id: indexTypeId.id,
+      };
+
+      switch (bulk[counter].type) {
+        case 'set':
+          operations.push({index: operationPayload});
+          operations.push({val: JSON.parse(bulk[counter].value)});
+          break;
+        case 'remove':
+          operations.push({delete: operationPayload});
+          break;
+        default:
+          continue;
+      }
+    }
+
+    // send bulk request
+    client.bulk({
+      body: operations,
+    }, (error, response) => {
+      parseResponse(error, response, callback);
+    });
+  }
+
+  close(callback) {
+    callback(null);
+  }
 };
 
 /** ************************

--- a/databases/elasticsearch_db.js
+++ b/databases/elasticsearch_db.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const es = require('elasticsearch');
 
 // initialize w/ default settings
@@ -30,8 +31,9 @@ const elasticsearchSettings = {
 
 let client;
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.db = null;
 
     this.settings = settings || {};

--- a/databases/mongodb_db.js
+++ b/databases/mongodb_db.js
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
-exports.Database = class {
+const AbstractDatabase = require('../lib/AbstractDatabase');
+
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.settings = settings;
 
     if (!this.settings.url) throw new Error('You must specify a mongodb url');

--- a/databases/mssql_db.js
+++ b/databases/mssql_db.js
@@ -21,11 +21,13 @@
  *
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const async = require('async');
 const mssql = require('mssql');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     settings = settings || {};
 
     if (settings.json != null) {

--- a/databases/mssql_db.js
+++ b/databases/mssql_db.js
@@ -24,191 +24,193 @@
 const async = require('async');
 const mssql = require('mssql');
 
-exports.Database = function (settings) {
-  settings = settings || {};
+exports.Database = class {
+  constructor(settings) {
+    settings = settings || {};
 
-  if (settings.json != null) {
-    settings.parseJSON = settings.json;
+    if (settings.json != null) {
+      settings.parseJSON = settings.json;
+    }
+
+    // set the request timeout to 5 minutes
+    settings.requestTimeout = 300000;
+
+    settings.server = settings.host;
+    this.settings = settings;
+
+    /*
+      Turning off the cache and write buffer here. You
+      can reenable it, but also take a look at maxInserts in
+      the doBulk function to decide how you want to split it up.
+    */
+    this.settings.cache = 0;
+    this.settings.writeInterval = 0;
   }
 
-  // set the request timeout to 5 minutes
-  settings.requestTimeout = 300000;
+  init(callback) {
+    const sqlCreate =
+        "IF OBJECT_ID(N'dbo.store', N'U') IS NULL" +
+        '  BEGIN' +
+        '    CREATE TABLE [store] (' +
+        '      [key] NVARCHAR(100) PRIMARY KEY,' +
+        '      [value] NTEXT NOT NULL' +
+        '    );' +
+        '  END';
 
-  settings.server = settings.host;
-  this.settings = settings;
+    new mssql.ConnectionPool(this.settings).connect().then((pool) => {
+      this.db = pool;
 
-  /*
-    Turning off the cache and write buffer here. You
-    can reenable it, but also take a look at maxInserts in
-    the doBulk function to decide how you want to split it up.
-  */
-  this.settings.cache = 0;
-  this.settings.writeInterval = 0;
-};
+      const request = new mssql.Request(this.db);
 
-exports.Database.prototype.init = function (callback) {
-  const sqlCreate =
-    "IF OBJECT_ID(N'dbo.store', N'U') IS NULL" +
-    '  BEGIN' +
-    '    CREATE TABLE [store] (' +
-    '      [key] NVARCHAR(100) PRIMARY KEY,' +
-    '      [value] NTEXT NOT NULL' +
-    '    );' +
-    '  END';
+      request.query(sqlCreate, (err) => {
+        callback(err);
+      });
 
-  new mssql.ConnectionPool(this.settings).connect().then((pool) => {
-    this.db = pool;
+      this.db.on('error', (err) => {
+        console.log(err);
+      });
+    });
+  }
 
+  get(key, callback) {
     const request = new mssql.Request(this.db);
 
-    request.query(sqlCreate, (err) => {
-      callback(err);
+    request.input('key', mssql.NVarChar(100), key);
+
+    request.query('SELECT [value] FROM [store] WHERE [key] = @key', (err, results) => {
+      let value = null;
+
+      if (!err && results.rowsAffected[0] === 1) {
+        value = results.recordset[0].value;
+      }
+
+      callback(err, value);
     });
-
-    this.db.on('error', (err) => {
-      console.log(err);
-    });
-  });
-};
-
-exports.Database.prototype.get = function (key, callback) {
-  const request = new mssql.Request(this.db);
-
-  request.input('key', mssql.NVarChar(100), key);
-
-  request.query('SELECT [value] FROM [store] WHERE [key] = @key', (err, results) => {
-    let value = null;
-
-    if (!err && results.rowsAffected[0] === 1) {
-      value = results.recordset[0].value;
-    }
-
-    callback(err, value);
-  });
-};
-
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  const request = new mssql.Request(this.db);
-  let query = 'SELECT [key] FROM [store] WHERE [key] LIKE @key';
-
-  // desired keys are key, e.g. pad:%
-  key = key.replace(/\*/g, '%');
-
-  request.input('key', mssql.NVarChar(100), key);
-
-  if (notKey != null) {
-    // not desired keys are notKey, e.g. %:%:%
-    notKey = notKey.replace(/\*/g, '%');
-    request.input('notkey', mssql.NVarChar(100), notKey);
-    query += ' AND [key] NOT LIKE @notkey';
   }
 
-  request.query(query, (err, results) => {
-    const value = [];
+  findKeys(key, notKey, callback) {
+    const request = new mssql.Request(this.db);
+    let query = 'SELECT [key] FROM [store] WHERE [key] LIKE @key';
 
-    if (!err && results.rowsAffected[0] > 0) {
-      for (let i = 0; i < results.recordset.length; i++) {
-        value.push(results.recordset[i].key);
-      }
-    }
-
-    callback(err, value);
-  });
-};
-
-exports.Database.prototype.set = function (key, value, callback) {
-  const request = new mssql.Request(this.db);
-
-  if (key.length > 100) {
-    callback('Your Key can only be 100 chars');
-  } else {
-    const query =
-      'MERGE [store] t USING (SELECT @key [key], @value [value]) s' +
-      ' ON t.[key] = s.[key]' +
-      ' WHEN MATCHED AND s.[value] IS NOT NULL THEN UPDATE SET t.[value] = s.[value]' +
-      ' WHEN NOT MATCHED THEN INSERT ([key], [value]) VALUES (s.[key], s.[value]);';
+    // desired keys are key, e.g. pad:%
+    key = key.replace(/\*/g, '%');
 
     request.input('key', mssql.NVarChar(100), key);
-    request.input('value', mssql.NText, value);
 
-    request.query(query, (err, info) => {
-      callback(err);
+    if (notKey != null) {
+      // not desired keys are notKey, e.g. %:%:%
+      notKey = notKey.replace(/\*/g, '%');
+      request.input('notkey', mssql.NVarChar(100), notKey);
+      query += ' AND [key] NOT LIKE @notkey';
+    }
+
+    request.query(query, (err, results) => {
+      const value = [];
+
+      if (!err && results.rowsAffected[0] > 0) {
+        for (let i = 0; i < results.recordset.length; i++) {
+          value.push(results.recordset[i].key);
+        }
+      }
+
+      callback(err, value);
     });
   }
-};
 
-exports.Database.prototype.remove = function (key, callback) {
-  const request = new mssql.Request(this.db);
-  request.input('key', mssql.NVarChar(100), key);
-  request.query('DELETE FROM [store] WHERE [key] = @key', callback);
-};
+  set(key, value, callback) {
+    const request = new mssql.Request(this.db);
 
-exports.Database.prototype.doBulk = function (bulk, callback) {
-  const maxInserts = 100;
-  const request = new mssql.Request(this.db);
-  let firstReplace = true;
-  let firstRemove = true;
-  const replacements = [];
-  let removeSQL = 'DELETE FROM [store] WHERE [key] IN (';
+    if (key.length > 100) {
+      callback('Your Key can only be 100 chars');
+    } else {
+      const query =
+          'MERGE [store] t USING (SELECT @key [key], @value [value]) s' +
+          ' ON t.[key] = s.[key]' +
+          ' WHEN MATCHED AND s.[value] IS NOT NULL THEN UPDATE SET t.[value] = s.[value]' +
+          ' WHEN NOT MATCHED THEN INSERT ([key], [value]) VALUES (s.[key], s.[value]);';
 
-  for (const i in bulk) {
-    if (bulk[i].type === 'set') {
-      if (firstReplace) {
-        replacements.push('BEGIN TRANSACTION;');
-        firstReplace = false;
-      } else if (i % maxInserts === 0) {
-        replacements.push('\nCOMMIT TRANSACTION;\nBEGIN TRANSACTION;\n');
-      }
+      request.input('key', mssql.NVarChar(100), key);
+      request.input('value', mssql.NText, value);
 
-      replacements.push(
-          `MERGE [store] t USING (SELECT '${bulk[i].key}' [key], '${bulk[i].value}' [value]) s`,
-          'ON t.[key] = s.[key]',
-          'WHEN MATCHED AND s.[value] IS NOT NULL THEN UPDATE SET t.[value] = s.[value]',
-          'WHEN NOT MATCHED THEN INSERT ([key], [value]) VALUES (s.[key], s.[value]);');
-    } else if (bulk[i].type === 'remove') {
-      if (!firstRemove) {
-        removeSQL += ',';
-      }
-
-      firstRemove = false;
-      removeSQL += `'${bulk[i].key}'`;
+      request.query(query, (err, info) => {
+        callback(err);
+      });
     }
   }
 
-  removeSQL += ');';
-  replacements.push('COMMIT TRANSACTION;');
+  remove(key, callback) {
+    const request = new mssql.Request(this.db);
+    request.input('key', mssql.NVarChar(100), key);
+    request.query('DELETE FROM [store] WHERE [key] = @key', callback);
+  }
 
-  async.parallel(
-      [
-        (callback) => {
-          if (!firstReplace) {
-            request.batch(replacements.join('\n'), (err, results) => {
-              if (err) {
-                callback(err);
-              }
-              callback(err, results);
-            });
-          } else {
-            callback();
-          }
-        },
-        (callback) => {
-          if (!firstRemove) {
-            request.query(removeSQL, callback);
-          } else {
-            callback();
-          }
-        },
-      ],
-      (err, results) => {
-        if (err) {
-          callback(err);
+  doBulk(bulk, callback) {
+    const maxInserts = 100;
+    const request = new mssql.Request(this.db);
+    let firstReplace = true;
+    let firstRemove = true;
+    const replacements = [];
+    let removeSQL = 'DELETE FROM [store] WHERE [key] IN (';
+
+    for (const i in bulk) {
+      if (bulk[i].type === 'set') {
+        if (firstReplace) {
+          replacements.push('BEGIN TRANSACTION;');
+          firstReplace = false;
+        } else if (i % maxInserts === 0) {
+          replacements.push('\nCOMMIT TRANSACTION;\nBEGIN TRANSACTION;\n');
         }
-        callback(err, results);
-      }
-  );
-};
 
-exports.Database.prototype.close = function (callback) {
-  this.db.close(callback);
+        replacements.push(
+            `MERGE [store] t USING (SELECT '${bulk[i].key}' [key], '${bulk[i].value}' [value]) s`,
+            'ON t.[key] = s.[key]',
+            'WHEN MATCHED AND s.[value] IS NOT NULL THEN UPDATE SET t.[value] = s.[value]',
+            'WHEN NOT MATCHED THEN INSERT ([key], [value]) VALUES (s.[key], s.[value]);');
+      } else if (bulk[i].type === 'remove') {
+        if (!firstRemove) {
+          removeSQL += ',';
+        }
+
+        firstRemove = false;
+        removeSQL += `'${bulk[i].key}'`;
+      }
+    }
+
+    removeSQL += ');';
+    replacements.push('COMMIT TRANSACTION;');
+
+    async.parallel(
+        [
+          (callback) => {
+            if (!firstReplace) {
+              request.batch(replacements.join('\n'), (err, results) => {
+                if (err) {
+                  callback(err);
+                }
+                callback(err, results);
+              });
+            } else {
+              callback();
+            }
+          },
+          (callback) => {
+            if (!firstRemove) {
+              request.query(removeSQL, callback);
+            } else {
+              callback();
+            }
+          },
+        ],
+        (err, results) => {
+          if (err) {
+            callback(err);
+          }
+          callback(err, results);
+        }
+    );
+  }
+
+  close(callback) {
+    this.db.close(callback);
+  }
 };

--- a/databases/mysql_db.js
+++ b/databases/mysql_db.js
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const mysql = require('mysql');
 const util = require('util');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.logger = console;
     this._mysqlSettings = {
       charset: 'utf8mb4', // temp hack needs a proper fix..

--- a/databases/postgres_common.js
+++ b/databases/postgres_common.js
@@ -17,161 +17,163 @@
 
 const async = require('async');
 
-exports.init = function (callback) {
-  const testTableExists = "SELECT 1 as exists FROM pg_tables WHERE tablename = 'store'";
+exports.Database = class {
+  init(callback) {
+    const testTableExists = "SELECT 1 as exists FROM pg_tables WHERE tablename = 'store'";
 
-  const createTable = 'CREATE TABLE IF NOT EXISTS store (' +
-    '"key" character varying(100) NOT NULL, ' +
-    '"value" text NOT NULL, ' +
-    'CONSTRAINT store_pkey PRIMARY KEY (key))';
+    const createTable = 'CREATE TABLE IF NOT EXISTS store (' +
+                        '"key" character varying(100) NOT NULL, ' +
+                        '"value" text NOT NULL, ' +
+                        'CONSTRAINT store_pkey PRIMARY KEY (key))';
 
-  // this variable will be given a value depending on the result of the
-  // feature detection
-  this.upsertStatement = null;
+    // this variable will be given a value depending on the result of the
+    // feature detection
+    this.upsertStatement = null;
 
-  /*
-   * - Detects if this Postgres version supports INSERT .. ON CONFLICT
-   *   UPDATE (PostgreSQL >= 9.5 and CockroachDB)
-   * - If upsert is not supported natively, creates in the DB a pl/pgsql
-   *   function that emulates it
-   * - Performs a side effect, setting this.upsertStatement to the sql
-   *   statement that needs to be used, based on the detection result
-   * - calls the callback
-   */
-  const detectUpsertMethod = (callback) => {
-    const upsertViaFunction = 'SELECT ueberdb_insert_or_update($1,$2)';
-    const upsertNatively =
-        'INSERT INTO store(key, value) VALUES ($1, $2) ' +
-        'ON CONFLICT (key) DO UPDATE SET value = excluded.value';
-    const createFunc =
-        'CREATE OR REPLACE FUNCTION ueberdb_insert_or_update(character varying, text) ' +
-        'RETURNS void AS $$ ' +
-        'BEGIN ' +
-        '  IF EXISTS( SELECT * FROM store WHERE key = $1 ) THEN ' +
-        '    UPDATE store SET value = $2 WHERE key = $1; ' +
-        '  ELSE ' +
-        '    INSERT INTO store(key,value) VALUES( $1, $2 ); ' +
-        '  END IF; ' +
-        '  RETURN; ' +
-        'END; ' +
-        '$$ LANGUAGE plpgsql;';
+    /*
+     * - Detects if this Postgres version supports INSERT .. ON CONFLICT
+     *   UPDATE (PostgreSQL >= 9.5 and CockroachDB)
+     * - If upsert is not supported natively, creates in the DB a pl/pgsql
+     *   function that emulates it
+     * - Performs a side effect, setting this.upsertStatement to the sql
+     *   statement that needs to be used, based on the detection result
+     * - calls the callback
+     */
+    const detectUpsertMethod = (callback) => {
+      const upsertViaFunction = 'SELECT ueberdb_insert_or_update($1,$2)';
+      const upsertNatively =
+          'INSERT INTO store(key, value) VALUES ($1, $2) ' +
+          'ON CONFLICT (key) DO UPDATE SET value = excluded.value';
+      const createFunc =
+          'CREATE OR REPLACE FUNCTION ueberdb_insert_or_update(character varying, text) ' +
+          'RETURNS void AS $$ ' +
+          'BEGIN ' +
+          '  IF EXISTS( SELECT * FROM store WHERE key = $1 ) THEN ' +
+          '    UPDATE store SET value = $2 WHERE key = $1; ' +
+          '  ELSE ' +
+          '    INSERT INTO store(key,value) VALUES( $1, $2 ); ' +
+          '  END IF; ' +
+          '  RETURN; ' +
+          'END; ' +
+          '$$ LANGUAGE plpgsql;';
 
-    const testNativeUpsert = `EXPLAIN ${upsertNatively}`;
+      const testNativeUpsert = `EXPLAIN ${upsertNatively}`;
 
-    this.db.query(testNativeUpsert, ['test-key', 'test-value'], (err) => {
-      if (err) {
-        // the UPSERT statement failed: we will have to emulate it via
-        // an sql function
-        this.upsertStatement = upsertViaFunction;
+      this.db.query(testNativeUpsert, ['test-key', 'test-value'], (err) => {
+        if (err) {
+          // the UPSERT statement failed: we will have to emulate it via
+          // an sql function
+          this.upsertStatement = upsertViaFunction;
 
-        // actually create the emulation function
-        this.db.query(createFunc, [], callback);
+          // actually create the emulation function
+          this.db.query(createFunc, [], callback);
 
-        return;
+          return;
+        }
+
+        // if we get here, the EXPLAIN UPSERT succeeded, and we can use a
+        // native UPSERT
+        this.upsertStatement = upsertNatively;
+        callback();
+      });
+    };
+
+    this.db.query(testTableExists, (err, result) => {
+      if (err != null) return callback(err);
+      if (result.rows.length === 0) {
+        this.db.query(createTable, (err) => {
+          if (err != null) return callback(err);
+          detectUpsertMethod(callback);
+        });
+      } else {
+        detectUpsertMethod(callback);
+      }
+    });
+  }
+
+  get(key, callback) {
+    this.db.query('SELECT value FROM store WHERE key=$1', [key], (err, results) => {
+      let value = null;
+
+      if (!err && results.rows.length === 1) {
+        value = results.rows[0].value;
       }
 
-      // if we get here, the EXPLAIN UPSERT succeeded, and we can use a
-      // native UPSERT
-      this.upsertStatement = upsertNatively;
-      callback();
+      callback(err, value);
     });
-  };
+  }
 
-  this.db.query(testTableExists, (err, result) => {
-    if (err != null) return callback(err);
-    if (result.rows.length === 0) {
-      this.db.query(createTable, (err) => {
-        if (err != null) return callback(err);
-        detectUpsertMethod(callback);
-      });
+  findKeys(key, notKey, callback) {
+    let query = 'SELECT key FROM store WHERE key LIKE $1';
+    const params = [];
+    // desired keys are %key:%, e.g. pad:%
+    key = key.replace(/\*/g, '%');
+    params.push(key);
+
+    if (notKey != null) {
+      // not desired keys are notKey:%, e.g. %:%:%
+      notKey = notKey.replace(/\*/g, '%');
+      query += ' AND key NOT LIKE $2';
+      params.push(notKey);
+    }
+    this.db.query(query, params, (err, results) => {
+      const value = [];
+
+      if (!err && results.rows.length > 0) {
+        results.rows.forEach((val) => {
+          value.push(val.key);
+        });
+      }
+
+      callback(err, value);
+    });
+  }
+
+  set(key, value, callback) {
+    if (key.length > 100) {
+      callback('Your Key can only be 100 chars');
     } else {
-      detectUpsertMethod(callback);
-    }
-  });
-};
-
-exports.get = function (key, callback) {
-  this.db.query('SELECT value FROM store WHERE key=$1', [key], (err, results) => {
-    let value = null;
-
-    if (!err && results.rows.length === 1) {
-      value = results.rows[0].value;
-    }
-
-    callback(err, value);
-  });
-};
-
-exports.findKeys = function (key, notKey, callback) {
-  let query = 'SELECT key FROM store WHERE key LIKE $1';
-  const params = [];
-  // desired keys are %key:%, e.g. pad:%
-  key = key.replace(/\*/g, '%');
-  params.push(key);
-
-  if (notKey != null) {
-    // not desired keys are notKey:%, e.g. %:%:%
-    notKey = notKey.replace(/\*/g, '%');
-    query += ' AND key NOT LIKE $2';
-    params.push(notKey);
-  }
-  this.db.query(query, params, (err, results) => {
-    const value = [];
-
-    if (!err && results.rows.length > 0) {
-      results.rows.forEach((val) => {
-        value.push(val.key);
-      });
-    }
-
-    callback(err, value);
-  });
-};
-
-exports.set = function (key, value, callback) {
-  if (key.length > 100) {
-    callback('Your Key can only be 100 chars');
-  } else {
-    this.db.query(this.upsertStatement, [key, value], callback);
-  }
-};
-
-exports.remove = function (key, callback) {
-  this.db.query('DELETE FROM store WHERE key=$1', [key], callback);
-};
-
-exports.doBulk = function (bulk, callback) {
-  const replaceVALs = [];
-  let removeSQL = 'DELETE FROM store WHERE key IN (';
-  const removeVALs = [];
-
-  let removeCount = 0;
-
-  for (const i in bulk) {
-    if (bulk[i].type === 'set') {
-      replaceVALs.push([bulk[i].key, bulk[i].value]);
-    } else if (bulk[i].type === 'remove') {
-      if (removeCount !== 0) removeSQL += ',';
-      removeCount += 1;
-
-      removeSQL += `$${removeCount}`;
-      removeVALs.push(bulk[i].key);
+      this.db.query(this.upsertStatement, [key, value], callback);
     }
   }
 
-  removeSQL += ');';
+  remove(key, callback) {
+    this.db.query('DELETE FROM store WHERE key=$1', [key], callback);
+  }
 
-  const functions = replaceVALs.map((v) => (cb) => this.db.query(this.upsertStatement, v, cb));
+  doBulk(bulk, callback) {
+    const replaceVALs = [];
+    let removeSQL = 'DELETE FROM store WHERE key IN (';
+    const removeVALs = [];
 
-  const removeFunction = (callback) => {
-    if (!removeVALs.length < 1) this.db.query(removeSQL, removeVALs, callback);
-    else callback();
-  };
-  functions.push(removeFunction);
+    let removeCount = 0;
 
-  async.parallel(functions, callback);
-};
+    for (const i in bulk) {
+      if (bulk[i].type === 'set') {
+        replaceVALs.push([bulk[i].key, bulk[i].value]);
+      } else if (bulk[i].type === 'remove') {
+        if (removeCount !== 0) removeSQL += ',';
+        removeCount += 1;
 
-exports.close = function (callback) {
-  this.db.end(callback);
+        removeSQL += `$${removeCount}`;
+        removeVALs.push(bulk[i].key);
+      }
+    }
+
+    removeSQL += ');';
+
+    const functions = replaceVALs.map((v) => (cb) => this.db.query(this.upsertStatement, v, cb));
+
+    const removeFunction = (callback) => {
+      if (!removeVALs.length < 1) this.db.query(removeSQL, removeVALs, callback);
+      else callback();
+    };
+    functions.push(removeFunction);
+
+    async.parallel(functions, callback);
+  }
+
+  close(callback) {
+    this.db.end(callback);
+  }
 };

--- a/databases/postgres_common.js
+++ b/databases/postgres_common.js
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const async = require('async');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   init(callback) {
     const testTableExists = "SELECT 1 as exists FROM pg_tables WHERE tablename = 'store'";
 

--- a/databases/postgres_db.js
+++ b/databases/postgres_db.js
@@ -18,21 +18,16 @@
 const pg = require('pg');
 const postgresCommon = require('./postgres_common');
 
-exports.Database = function (settings) {
-  this.settings = settings;
+exports.Database = class extends postgresCommon.Database {
+  constructor(settings) {
+    super();
+    this.settings = settings;
 
-  this.settings.cache = settings.cache || 1000;
-  this.settings.writeInterval = 100;
-  this.settings.json = true;
+    this.settings.cache = settings.cache || 1000;
+    this.settings.writeInterval = 100;
+    this.settings.json = true;
 
-  this.db = new pg.Client(this.settings);
-  this.db.connect();
+    this.db = new pg.Client(this.settings);
+    this.db.connect();
+  }
 };
-
-exports.Database.prototype.init = postgresCommon.init;
-exports.Database.prototype.get = postgresCommon.get;
-exports.Database.prototype.findKeys = postgresCommon.findKeys;
-exports.Database.prototype.set = postgresCommon.set;
-exports.Database.prototype.remove = postgresCommon.remove;
-exports.Database.prototype.doBulk = postgresCommon.doBulk;
-exports.Database.prototype.close = postgresCommon.close;

--- a/databases/postgrespool_db.js
+++ b/databases/postgrespool_db.js
@@ -18,25 +18,20 @@
 const pg = require('pg');
 const postgresCommon = require('./postgres_common');
 
-exports.Database = function (settings) {
-  this.settings = settings;
+exports.Database = class extends postgresCommon.Database {
+  constructor(settings) {
+    super();
+    this.settings = settings;
 
-  this.settings.cache = settings.cache || 1000;
-  this.settings.writeInterval = 100;
-  this.settings.json = true;
+    this.settings.cache = settings.cache || 1000;
+    this.settings.writeInterval = 100;
+    this.settings.json = true;
 
-  // Pool specific defaults
-  this.settings.max = this.settings.max || 20;
-  this.settings.min = this.settings.min || 4;
-  this.settings.idleTimeoutMillis = this.settings.idleTimeoutMillis || 1000;
+    // Pool specific defaults
+    this.settings.max = this.settings.max || 20;
+    this.settings.min = this.settings.min || 4;
+    this.settings.idleTimeoutMillis = this.settings.idleTimeoutMillis || 1000;
 
-  this.db = new pg.Pool(this.settings);
+    this.db = new pg.Pool(this.settings);
+  }
 };
-
-exports.Database.prototype.init = postgresCommon.init;
-exports.Database.prototype.get = postgresCommon.get;
-exports.Database.prototype.findKeys = postgresCommon.findKeys;
-exports.Database.prototype.set = postgresCommon.set;
-exports.Database.prototype.remove = postgresCommon.remove;
-exports.Database.prototype.doBulk = postgresCommon.doBulk;
-exports.Database.prototype.close = postgresCommon.close;

--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -17,11 +17,13 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const async = require('async');
 const redis = require('redis');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.client = null;
     this.settings = settings || {};
   }

--- a/databases/redis_db.js
+++ b/databases/redis_db.js
@@ -20,105 +20,107 @@
 const async = require('async');
 const redis = require('redis');
 
-exports.Database = function (settings) {
-  this.client = null;
-  this.settings = settings || {};
-};
-
-exports.Database.prototype.auth = function (callback) {
-  if (!this.settings.password) return callback();
-  this.client.auth(this.settings.password, callback);
-};
-
-exports.Database.prototype.select = function (callback) {
-  if (!this.settings.database) return callback();
-  this.client.select(this.settings.database, callback);
-};
-
-exports.Database.prototype._deprecatedInit = function (callback) {
-  if (this.settings.socket) {
-    // Deprecated, but kept for backwards compatibility.
-    this.client = redis.createClient(this.settings.socket,
-        this.settings.client_options);
-  } else {
-    // Deprecated, but kept for backwards compatibility.
-    this.client = redis.createClient(this.settings.port,
-        this.settings.host, this.settings.client_options);
+exports.Database = class {
+  constructor(settings) {
+    this.client = null;
+    this.settings = settings || {};
   }
 
-  this.client.database = this.settings.database;
-  async.waterfall([this.auth.bind(this), this.select.bind(this)], callback);
-};
+  auth(callback) {
+    if (!this.settings.password) return callback();
+    this.client.auth(this.settings.password, callback);
+  }
 
-exports.Database.prototype.init = function (callback) {
-  if (this.settings.socket || this.settings.client_options) return this._deprecatedInit(callback);
-  this.client = redis.createClient(this.settings);
-  callback();
-};
+  select(callback) {
+    if (!this.settings.database) return callback();
+    this.client.select(this.settings.database, callback);
+  }
 
-exports.Database.prototype.get = function (key, callback) {
-  this.client.get(key, callback);
-};
-
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  // As redis provides only limited support for getting a list of all
-  // available keys we have to limit key and notKey here.
-  // See http://redis.io/commands/keys
-  if (notKey == null) {
-    this.client.KEYS(key, callback);
-  } else if (notKey === '*:*:*') {
-    // restrict key to format "text:*"
-    const matches = /^([^:]+):\*$/.exec(key);
-    if (matches) {
-      this.client.SMEMBERS(`ueberDB:keys:${matches[1]}`, callback);
+  _deprecatedInit(callback) {
+    if (this.settings.socket) {
+      // Deprecated, but kept for backwards compatibility.
+      this.client = redis.createClient(this.settings.socket,
+          this.settings.client_options);
     } else {
-      const msg = 'redis db only supports key patterns like pad:* when notKey is set to *:*:*';
-      callback(new Error(msg), null);
+      // Deprecated, but kept for backwards compatibility.
+      this.client = redis.createClient(this.settings.port,
+          this.settings.host, this.settings.client_options);
     }
-  } else {
-    callback(new Error('redis db currently only supports *:*:* as notKey'), null);
-  }
-};
 
-exports.Database.prototype.set = function (key, value, callback) {
-  const matches = /^([^:]+):([^:]+)$/.exec(key);
-  if (matches) {
-    this.client.sadd([`ueberDB:keys:${matches[1]}`, matches[0]]);
-  }
-  this.client.set(key, value, callback);
-};
-
-exports.Database.prototype.remove = function (key, callback) {
-  const matches = /^([^:]+):([^:]+)$/.exec(key);
-  if (matches) {
-    this.client.srem([`ueberDB:keys:${matches[1]}`, matches[0]]);
-  }
-  this.client.del(key, callback);
-};
-
-exports.Database.prototype.doBulk = function (bulk, callback) {
-  const multi = this.client.multi();
-
-  for (const {key, type, value} of bulk) {
-    const matches = /^([^:]+):([^:]+)$/.exec(key);
-    if (type === 'set') {
-      if (matches) {
-        multi.sadd([`ueberDB:keys:${matches[1]}`, matches[0]]);
-      }
-      multi.set(key, value);
-    } else if (type === 'remove') {
-      if (matches) {
-        multi.srem([`ueberDB:keys:${matches[1]}`, matches[0]]);
-      }
-      multi.del(key);
-    }
+    this.client.database = this.settings.database;
+    async.waterfall([this.auth.bind(this), this.select.bind(this)], callback);
   }
 
-  multi.exec(callback);
-};
-
-exports.Database.prototype.close = function (callback) {
-  this.client.quit(() => {
+  init(callback) {
+    if (this.settings.socket || this.settings.client_options) return this._deprecatedInit(callback);
+    this.client = redis.createClient(this.settings);
     callback();
-  });
+  }
+
+  get(key, callback) {
+    this.client.get(key, callback);
+  }
+
+  findKeys(key, notKey, callback) {
+    // As redis provides only limited support for getting a list of all
+    // available keys we have to limit key and notKey here.
+    // See http://redis.io/commands/keys
+    if (notKey == null) {
+      this.client.KEYS(key, callback);
+    } else if (notKey === '*:*:*') {
+      // restrict key to format "text:*"
+      const matches = /^([^:]+):\*$/.exec(key);
+      if (matches) {
+        this.client.SMEMBERS(`ueberDB:keys:${matches[1]}`, callback);
+      } else {
+        const msg = 'redis db only supports key patterns like pad:* when notKey is set to *:*:*';
+        callback(new Error(msg), null);
+      }
+    } else {
+      callback(new Error('redis db currently only supports *:*:* as notKey'), null);
+    }
+  }
+
+  set(key, value, callback) {
+    const matches = /^([^:]+):([^:]+)$/.exec(key);
+    if (matches) {
+      this.client.sadd([`ueberDB:keys:${matches[1]}`, matches[0]]);
+    }
+    this.client.set(key, value, callback);
+  }
+
+  remove(key, callback) {
+    const matches = /^([^:]+):([^:]+)$/.exec(key);
+    if (matches) {
+      this.client.srem([`ueberDB:keys:${matches[1]}`, matches[0]]);
+    }
+    this.client.del(key, callback);
+  }
+
+  doBulk(bulk, callback) {
+    const multi = this.client.multi();
+
+    for (const {key, type, value} of bulk) {
+      const matches = /^([^:]+):([^:]+)$/.exec(key);
+      if (type === 'set') {
+        if (matches) {
+          multi.sadd([`ueberDB:keys:${matches[1]}`, matches[0]]);
+        }
+        multi.set(key, value);
+      } else if (type === 'remove') {
+        if (matches) {
+          multi.srem([`ueberDB:keys:${matches[1]}`, matches[0]]);
+        }
+        multi.del(key);
+      }
+    }
+
+    multi.exec(callback);
+  }
+
+  close(callback) {
+    this.client.quit(() => {
+      callback();
+    });
+  }
 };

--- a/databases/rethink_db.js
+++ b/databases/rethink_db.js
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const r = require('rethinkdb');
 const async = require('async');
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     if (!settings) settings = {};
     if (!settings.host) { settings.host = 'localhost'; }
     if (!settings.port) { settings.port = 28015; }

--- a/databases/sqlite_db.js
+++ b/databases/sqlite_db.js
@@ -29,126 +29,128 @@ const util = require('util');
 
 const escape = (val) => `'${val.replace(/'/g, "''")}'`;
 
-exports.Database = function (settings) {
-  this.db = null;
+exports.Database = class {
+  constructor(settings) {
+    this.db = null;
 
-  if (!settings || !settings.filename) {
-    settings = {filename: ':memory:'};
+    if (!settings || !settings.filename) {
+      settings = {filename: ':memory:'};
+    }
+
+    this.settings = settings;
+
+    // set settings for the dbWrapper
+    if (settings.filename === ':memory:') {
+      this.settings.cache = 0;
+      this.settings.writeInterval = 0;
+      this.settings.json = true;
+    } else {
+      this.settings.cache = 1000;
+      this.settings.writeInterval = 100;
+      this.settings.json = true;
+    }
   }
 
-  this.settings = settings;
-
-  // set settings for the dbWrapper
-  if (settings.filename === ':memory:') {
-    this.settings.cache = 0;
-    this.settings.writeInterval = 0;
-    this.settings.json = true;
-  } else {
-    this.settings.cache = 1000;
-    this.settings.writeInterval = 100;
-    this.settings.json = true;
-  }
-};
-
-exports.Database.prototype._query = async function (sql, params = []) {
-  // It is unclear how util.promisify() deals with variadic functions, so it is not used here.
-  return await new Promise((resolve, reject) => {
-    // According to sqlite3's documentation, .run() method (and maybe .all() and .get(); the
-    // documentation is unclear) might call the callback multiple times. That's OK -- ECMAScript
-    // guarantees that it is safe to call a Promise executor's resolve and reject functions multiple
-    // times. The subsequent calls are ignored, except Node.js's 'process' object emits a
-    // 'multipleResolves' event to aid in debugging.
-    this.db.all(sql, params, (err, rows) => {
-      if (err != null) return reject(err);
-      resolve(rows);
-    });
-  });
-};
-
-// Temporary callbackified version of _query. This will be removed once all database objects are
-// asyncified.
-exports.Database.prototype._queryCb = function (sql, params, callback) {
-  // It is unclear how util.callbackify() handles optional parameters, so it is not used here.
-  const p = this._query(sql, params);
-  if (callback) p.then((rows) => callback(null, rows), (err) => callback(err || new Error(err)));
-};
-
-exports.Database.prototype.init = function (callback) {
-  util.callbackify(async () => {
-    this.db = await new Promise((resolve, reject) => {
-      new sqlite3.Database(this.settings.filename, function (err) {
+  async _query(sql, params = []) {
+    // It is unclear how util.promisify() deals with variadic functions, so it is not used here.
+    return await new Promise((resolve, reject) => {
+      // According to sqlite3's documentation, .run() method (and maybe .all() and .get(); the
+      // documentation is unclear) might call the callback multiple times. That's OK -- ECMAScript
+      // guarantees that it is safe to call a Promise executor's resolve and reject functions
+      // multiple times. The subsequent calls are ignored, except Node.js's 'process' object emits a
+      // 'multipleResolves' event to aid in debugging.
+      this.db.all(sql, params, (err, rows) => {
         if (err != null) return reject(err);
-        // The use of `this` relies on an undocumented feature of sqlite3:
-        // https://github.com/mapbox/node-sqlite3/issues/1408
-        resolve(this);
+        resolve(rows);
       });
     });
-    await this._query('CREATE TABLE IF NOT EXISTS store (key TEXT PRIMARY KEY, value TEXT)');
-  })(callback);
-};
-
-exports.Database.prototype.get = function (key, callback) {
-  this._queryCb(
-      'SELECT value FROM store WHERE key = ?', [key],
-      (err, rows) => callback(err, err == null && rows && rows.length ? rows[0].value : null));
-};
-
-exports.Database.prototype.findKeys = function (key, notKey, callback) {
-  let query = 'SELECT key FROM store WHERE key LIKE ?';
-  const params = [];
-  // desired keys are %key:%, e.g. pad:%
-  key = key.replace(/\*/g, '%');
-  params.push(key);
-
-  if (notKey != null) {
-    // not desired keys are notKey:%, e.g. %:%:%
-    notKey = notKey.replace(/\*/g, '%');
-    query += ' AND key NOT LIKE ?';
-    params.push(notKey);
   }
 
-  this._queryCb(query, params, (err, results) => {
-    const value = [];
+  // Temporary callbackified version of _query. This will be removed once all database objects are
+  // asyncified.
+  _queryCb(sql, params, callback) {
+    // It is unclear how util.callbackify() handles optional parameters, so it is not used here.
+    const p = this._query(sql, params);
+    if (callback) p.then((rows) => callback(null, rows), (err) => callback(err || new Error(err)));
+  }
 
-    if (!err && Object.keys(results).length > 0) {
-      results.forEach((val) => {
-        value.push(val.key);
+  init(callback) {
+    util.callbackify(async () => {
+      this.db = await new Promise((resolve, reject) => {
+        new sqlite3.Database(this.settings.filename, function (err) {
+          if (err != null) return reject(err);
+          // The use of `this` relies on an undocumented feature of sqlite3:
+          // https://github.com/mapbox/node-sqlite3/issues/1408
+          resolve(this);
+        });
       });
-    }
-
-    callback(err, value);
-  });
-};
-
-exports.Database.prototype.set = function (key, value, callback) {
-  this._queryCb('REPLACE INTO store VALUES (?,?)', [key, value], callback);
-};
-
-exports.Database.prototype.remove = function (key, callback) {
-  this._queryCb('DELETE FROM store WHERE key = ?', [key], callback);
-};
-
-exports.Database.prototype.doBulk = function (bulk, callback) {
-  let sql = 'BEGIN TRANSACTION;\n';
-  for (const i in bulk) {
-    if (bulk[i].type === 'set') {
-      sql += `REPLACE INTO store VALUES (${escape(bulk[i].key)}, ${escape(bulk[i].value)});\n`;
-    } else if (bulk[i].type === 'remove') {
-      sql += `DELETE FROM store WHERE key = ${escape(bulk[i].key)};\n`;
-    }
+      await this._query('CREATE TABLE IF NOT EXISTS store (key TEXT PRIMARY KEY, value TEXT)');
+    })(callback);
   }
-  sql += 'END TRANSACTION;';
 
-  this.db.exec(sql, (err) => {
-    if (err) {
-      console.error('ERROR WITH SQL: ');
-      console.error(sql);
+  get(key, callback) {
+    this._queryCb(
+        'SELECT value FROM store WHERE key = ?', [key],
+        (err, rows) => callback(err, err == null && rows && rows.length ? rows[0].value : null));
+  }
+
+  findKeys(key, notKey, callback) {
+    let query = 'SELECT key FROM store WHERE key LIKE ?';
+    const params = [];
+    // desired keys are %key:%, e.g. pad:%
+    key = key.replace(/\*/g, '%');
+    params.push(key);
+
+    if (notKey != null) {
+      // not desired keys are notKey:%, e.g. %:%:%
+      notKey = notKey.replace(/\*/g, '%');
+      query += ' AND key NOT LIKE ?';
+      params.push(notKey);
     }
 
-    callback(err);
-  });
-};
+    this._queryCb(query, params, (err, results) => {
+      const value = [];
 
-exports.Database.prototype.close = function (callback) {
-  this.db.close(callback);
+      if (!err && Object.keys(results).length > 0) {
+        results.forEach((val) => {
+          value.push(val.key);
+        });
+      }
+
+      callback(err, value);
+    });
+  }
+
+  set(key, value, callback) {
+    this._queryCb('REPLACE INTO store VALUES (?,?)', [key, value], callback);
+  }
+
+  remove(key, callback) {
+    this._queryCb('DELETE FROM store WHERE key = ?', [key], callback);
+  }
+
+  doBulk(bulk, callback) {
+    let sql = 'BEGIN TRANSACTION;\n';
+    for (const i in bulk) {
+      if (bulk[i].type === 'set') {
+        sql += `REPLACE INTO store VALUES (${escape(bulk[i].key)}, ${escape(bulk[i].value)});\n`;
+      } else if (bulk[i].type === 'remove') {
+        sql += `DELETE FROM store WHERE key = ${escape(bulk[i].key)};\n`;
+      }
+    }
+    sql += 'END TRANSACTION;';
+
+    this.db.exec(sql, (err) => {
+      if (err) {
+        console.error('ERROR WITH SQL: ');
+        console.error(sql);
+      }
+
+      callback(err);
+    });
+  }
+
+  close(callback) {
+    this.db.close(callback);
+  }
 };

--- a/databases/sqlite_db.js
+++ b/databases/sqlite_db.js
@@ -25,12 +25,14 @@ try {
       '"npm install sqlite3" in your etherpad-lite root folder.');
 }
 
+const AbstractDatabase = require('../lib/AbstractDatabase');
 const util = require('util');
 
 const escape = (val) => `'${val.replace(/'/g, "''")}'`;
 
-exports.Database = class {
+exports.Database = class extends AbstractDatabase {
   constructor(settings) {
+    super();
     this.db = null;
 
     if (!settings || !settings.filename) {

--- a/lib/AbstractDatabase.js
+++ b/lib/AbstractDatabase.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = class AbstractDatabase {
+  constructor() {
+    if (new.target === module.exports) {
+      throw new TypeError('cannot instantiate Abstract Database directly');
+    }
+    for (const fn of ['init', 'close', 'get', 'findKeys', 'remove', 'set']) {
+      if (typeof this[fn] !== 'function') throw new TypeError(`method ${fn} not defined`);
+    }
+  }
+
+  doBulk(operations, cb) {
+    throw new Error('the doBulk method must be implemented if write caching is enabled');
+  }
+
+  get isAsync() { return false; }
+};

--- a/lib/AbstractDatabase.js
+++ b/lib/AbstractDatabase.js
@@ -10,6 +10,20 @@ module.exports = class AbstractDatabase {
     }
   }
 
+  /**
+   * For findKey regex. Used by document dbs like mongodb or dirty.
+   */
+  createFindRegex(key, notKey) {
+    let regex = '';
+    key = key.replace(/\*/g, '.*');
+    regex = `(?=^${key}$)`;
+    if (notKey != null) {
+      notKey = notKey.replace(/\*/g, '.*');
+      regex += `(?!${notKey}$)`;
+    }
+    return new RegExp(regex);
+  }
+
   doBulk(operations, cb) {
     throw new Error('the doBulk method must be implemented if write caching is enabled');
   }

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -131,460 +131,461 @@ const defaultSettings =
   charset: 'utf8mb4',
 };
 
-/**
- The constructor of the wrapper
- @param wrappedDB The Database that should be wrapped
- @param settings (optional) The settings that should be applied to the wrapper
-*/
-exports.Database = function (wrappedDB, settings, logger) {
-  // wrappedDB.isAsync is a temporary boolean that will go away once we have migrated all of the
-  // database drivers from callback-based methods to async methods.
-  if (wrappedDB.isAsync) {
-    this.wrappedDB = wrappedDB;
-  } else {
-    this.wrappedDB = {};
-    for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
-      const f = wrappedDB[fn];
-      if (typeof f !== 'function') continue;
-      this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
+exports.Database = class {
+  /**
+   * @param wrappedDB The Database that should be wrapped
+   * @param settings (optional) The settings that should be applied to the wrapper
+   */
+  constructor(wrappedDB, settings, logger) {
+    // wrappedDB.isAsync is a temporary boolean that will go away once we have migrated all of the
+    // database drivers from callback-based methods to async methods.
+    if (wrappedDB.isAsync) {
+      this.wrappedDB = wrappedDB;
+    } else {
+      this.wrappedDB = {};
+      for (const fn of ['close', 'doBulk', 'findKeys', 'get', 'init', 'remove', 'set']) {
+        const f = wrappedDB[fn];
+        if (typeof f !== 'function') continue;
+        this.wrappedDB[fn] = util.promisify(f.bind(wrappedDB));
+      }
     }
+    this.logger = logger;
+
+    this.settings = Object.freeze({
+      ...defaultSettings,
+      ...(wrappedDB.settings || {}),
+      ...(settings || {}),
+    });
+
+    // The key is the database key. The value is an object with the following properties:
+    //   - value: The entry's value.
+    //   - dirty: If the value has not yet been written, this is a Promise that will resolve once
+    //     the write to the underlying database returns. If the value has been written this is null.
+    //   - writingInProgress: Boolean that if true indicates that the value has been sent to the
+    //     underlying database and we are awaiting commit.
+    this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
+
+    // Maps database key to a Promise that is resolved when the record is unlocked.
+    this._locks = new Map();
+
+    this.metrics = {
+      // Count of times a database operation had to wait for the release of a record lock.
+      lockAwaits: 0,
+      // Count of times a record was locked.
+      lockAcquires: 0,
+      // Count of times a record was unlocked.
+      lockReleases: 0,
+
+      // Count of read operations (number of times `get()`, `getSub()`, and `setSub()` were called).
+      // This minus `readsFinished` is the number of currently pending read operations.
+      reads: 0,
+      // Count of times a read operation failed, including JSON parsing errors. This divided by
+      // `readsFinished` is the overall read error rate.
+      readsFailed: 0,
+      // Count of completed (successful or failed) read operations.
+      readsFinished: 0,
+      // Count of read operations that were satisfied from in-memory state (including the write
+      // buffer).
+      readsFromCache: 0,
+      // Count of times the database was queried for a value. This minus `readsFromDbFinished` is
+      // the number of in-progress reads.
+      readsFromDb: 0,
+      // Count of times the database failed to return a value. This does not include JSON parsing
+      // errors.
+      readsFromDbFailed: 0,
+      // Count of completed (successful or failed) value reads from the database. This plus
+      // `readsFromCache` equals `readsFinished`.
+      readsFromDbFinished: 0,
+
+      // Count of write operations (number of times `remove()`, `set()`, or `setSub()` was called)
+      // regardless of whether the value actually changed. This minus `writesFinished` is the
+      // current number of pending write operations.
+      writes: 0,
+      // Count of times a write operation failed, including JSON serialization errors. This divided
+      // by `writesFinished` is the overall write error rate.
+      writesFailed: 0,
+      // Count of completed (successful or failed) write operations.
+      writesFinished: 0,
+      // Count of times a pending write operation was not sent to the underlying database because a
+      // call to `remove()`, `set()`, or `setSub()` superseded the write, rendering it unnecessary.
+      writesObsoleted: 0,
+      // Count of times a value was sent to the underlying database, including record deletes but
+      // excluding retries. This minus `writesToDbFinished` is the number of in-progress writes.
+      writesToDb: 0,
+      // Count of times ueberDB failed to write a change to the underlying database, including
+      // failed record deletes. This does not include JSON serialization errors or write errors that
+      // later succeeded thanks to a retry by ueberDB.
+      writesToDbFailed: 0,
+      // Count of completed (successful or failed) value writes to the database. This plus
+      // `writesObsoleted` equals `writesFinished`.
+      writesToDbFinished: 0,
+      // Count of times a write operation was retried.
+      writesToDbRetried: 0,
+    };
+
+    // start the write Interval
+    this.flushInterval = this.settings.writeInterval > 0
+      ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
+
+    /**
+     * Adds function to db wrapper for findKey regex.
+     * Used by document dbs like mongodb or dirty.
+     */
+    wrappedDB.createFindRegex = (key, notKey) => {
+      let regex = '';
+      key = key.replace(/\*/g, '.*');
+      regex = `(?=^${key}$)`;
+      if (notKey != null) {
+        notKey = notKey.replace(/\*/g, '.*');
+        regex += `(?!${notKey}$)`;
+      }
+      return new RegExp(regex);
+    };
   }
-  this.logger = logger;
 
-  this.settings = Object.freeze({
-    ...defaultSettings,
-    ...(wrappedDB.settings || {}),
-    ...(settings || {}),
-  });
+  async _lock(key) {
+    while (true) {
+      const l = this._locks.get(key);
+      if (l == null) break;
+      ++this.metrics.lockAwaits;
+      await l;
+    }
+    ++this.metrics.lockAcquires;
+    this._locks.set(key, new SelfContainedPromise());
+  }
 
-  // The key is the database key. The value is an object with the following properties:
-  //   - value: The entry's value.
-  //   - dirty: If the value has not yet been written, this is a Promise that will resolve once the
-  //     write to the underlying database returns. If the value has been written this is null.
-  //   - writingInProgress: Boolean that if true indicates that the value has been sent to the
-  //     underlying database and we are awaiting commit.
-  this.buffer = new LRU(this.settings.cache, (k, v) => !v.dirty && !v.writingInProgress);
-
-  // Maps database key to a Promise that is resolved when the record is unlocked.
-  this._locks = new Map();
-
-  this.metrics = {
-    // Count of times a database operation had to wait for the release of a record lock.
-    lockAwaits: 0,
-    // Count of times a record was locked.
-    lockAcquires: 0,
-    // Count of times a record was unlocked.
-    lockReleases: 0,
-
-    // Count of read operations (number of times `get()`, `getSub()`, and `setSub()` were called).
-    // This minus `readsFinished` is the number of currently pending read operations.
-    reads: 0,
-    // Count of times a read operation failed, including JSON parsing errors. This divided by
-    // `readsFinished` is the overall read error rate.
-    readsFailed: 0,
-    // Count of completed (successful or failed) read operations.
-    readsFinished: 0,
-    // Count of read operations that were satisfied from in-memory state (including the write
-    // buffer).
-    readsFromCache: 0,
-    // Count of times the database was queried for a value. This minus `readsFromDbFinished` is the
-    // number of in-progress reads.
-    readsFromDb: 0,
-    // Count of times the database failed to return a value. This does not include JSON parsing
-    // errors.
-    readsFromDbFailed: 0,
-    // Count of completed (successful or failed) value reads from the database. This plus
-    // `readsFromCache` equals `readsFinished`.
-    readsFromDbFinished: 0,
-
-    // Count of write operations (number of times `remove()`, `set()`, or `setSub()` was called)
-    // regardless of whether the value actually changed. This minus `writesFinished` is the current
-    // number of pending write operations.
-    writes: 0,
-    // Count of times a write operation failed, including JSON serialization errors. This divided by
-    // `writesFinished` is the overall write error rate.
-    writesFailed: 0,
-    // Count of completed (successful or failed) write operations.
-    writesFinished: 0,
-    // Count of times a pending write operation was not sent to the underlying database because a
-    // call to `remove()`, `set()`, or `setSub()` superseded the write, rendering it unnecessary.
-    writesObsoleted: 0,
-    // Count of times a value was sent to the underlying database, including record deletes but
-    // excluding retries. This minus `writesToDbFinished` is the number of in-progress writes.
-    writesToDb: 0,
-    // Count of times ueberDB failed to write a change to the underlying database, including failed
-    // record deletes. This does not include JSON serialization errors or write errors that later
-    // succeeded thanks to a retry by ueberDB.
-    writesToDbFailed: 0,
-    // Count of completed (successful or failed) value writes to the database. This plus
-    // `writesObsoleted` equals `writesFinished`.
-    writesToDbFinished: 0,
-    // Count of times a write operation was retried.
-    writesToDbRetried: 0,
-  };
-
-  // start the write Interval
-  this.flushInterval = this.settings.writeInterval > 0
-    ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
+  async _unlock(key) {
+    ++this.metrics.lockReleases;
+    this._locks.get(key).done();
+    this._locks.delete(key);
+  }
 
   /**
-   * Adds function to db wrapper for findKey regex.
-   * Used by document dbs like mongodb or dirty.
+   * wraps the init function of the original DB
    */
-  wrappedDB.createFindRegex = (key, notKey) => {
-    let regex = '';
-    key = key.replace(/\*/g, '.*');
-    regex = `(?=^${key}$)`;
-    if (notKey != null) {
-      notKey = notKey.replace(/\*/g, '.*');
-      regex += `(?!${notKey}$)`;
-    }
-    return new RegExp(regex);
-  };
-};
-
-exports.Database.prototype._lock = async function (key) {
-  while (true) {
-    const l = this._locks.get(key);
-    if (l == null) break;
-    ++this.metrics.lockAwaits;
-    await l;
+  async init() {
+    await this.wrappedDB.init();
   }
-  ++this.metrics.lockAcquires;
-  this._locks.set(key, new SelfContainedPromise());
-};
 
-exports.Database.prototype._unlock = async function (key) {
-  ++this.metrics.lockReleases;
-  this._locks.get(key).done();
-  this._locks.delete(key);
-};
-
-/**
- wraps the init function of the original DB
-*/
-exports.Database.prototype.init = async function () {
-  await this.wrappedDB.init();
-};
-
-/**
- wraps the close function of the original DB
-*/
-exports.Database.prototype.close = async function () {
-  clearInterval(this.flushInterval);
-  await this.flush();
-  await this.wrappedDB.close();
-  this.wrappedDB = null;
-};
-
-/**
- Gets the value trough the wrapper.
-*/
-exports.Database.prototype.get = async function (key) {
-  await this._lock(key);
-  try {
-    return await this._getLocked(key);
-  } finally {
-    this._unlock(key);
+  /**
+   * wraps the close function of the original DB
+   */
+  async close() {
+    clearInterval(this.flushInterval);
+    await this.flush();
+    await this.wrappedDB.close();
+    this.wrappedDB = null;
   }
-};
 
-exports.Database.prototype._getLocked = async function (key) {
-  ++this.metrics.reads;
-  try {
-    const entry = this.buffer.get(key);
-    if (entry != null) {
-      ++this.metrics.readsFromCache;
-      if (this.logger.isDebugEnabled()) {
-        this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
-                          `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
-      }
-      return entry.value;
-    }
-
-    // get it direct
-    let value;
-    ++this.metrics.readsFromDb;
+  /**
+   * Gets the value trough the wrapper.
+   */
+  async get(key) {
+    await this._lock(key);
     try {
-      value = await this.wrappedDB.get(key);
+      return await this._getLocked(key);
+    } finally {
+      this._unlock(key);
+    }
+  }
+
+  async _getLocked(key) {
+    ++this.metrics.reads;
+    try {
+      const entry = this.buffer.get(key);
+      if (entry != null) {
+        ++this.metrics.readsFromCache;
+        if (this.logger.isDebugEnabled()) {
+          this.logger.debug(`GET    - ${key} - ${JSON.stringify(entry.value)} - ` +
+                            `from ${entry.dirty ? 'dirty buffer' : 'cache'}`);
+        }
+        return entry.value;
+      }
+
+      // get it direct
+      let value;
+      ++this.metrics.readsFromDb;
+      try {
+        value = await this.wrappedDB.get(key);
+      } catch (err) {
+        ++this.metrics.readsFromDbFailed;
+        throw err;
+      } finally {
+        ++this.metrics.readsFromDbFinished;
+      }
+      if (this.settings.json) {
+        try {
+          value = JSON.parse(value);
+        } catch (err) {
+          this.logger.error(`JSON-PROBLEM:${value}`);
+          throw err;
+        }
+      }
+
+      // cache the value if caching is enabled
+      if (this.settings.cache > 0) {
+        this.buffer.set(key, {
+          value,
+          dirty: null,
+          writingInProgress: false,
+        });
+      }
+
+      if (this.logger.isDebugEnabled()) {
+        this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
+      }
+
+      return value;
     } catch (err) {
-      ++this.metrics.readsFromDbFailed;
+      ++this.metrics.readsFailed;
       throw err;
     } finally {
-      ++this.metrics.readsFromDbFinished;
+      ++this.metrics.readsFinished;
     }
-    if (this.settings.json) {
+  }
+
+  /**
+   * Find keys function searches the db sets for matching entries and
+   * returns the key entries via callback.
+   */
+  async findKeys(key, notKey) {
+    const bufferKey = `${key}-${notKey}`;
+    const keyValues = await this.wrappedDB.findKeys(key, notKey);
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
+    }
+    return keyValues;
+  }
+
+  /**
+   * Remove a record from the database
+   */
+  async remove(key) {
+    if (this.logger.isDebugEnabled()) this.logger.debug(`DELETE - ${key} - from database `);
+    await this.set(key, null);
+  }
+
+  /**
+   * Sets the value trough the wrapper
+   */
+  async set(key, value) {
+    await this._lock(key);
+    const p = this._setLocked(key, value);
+    this._unlock(key);
+    await p;
+  }
+
+  // Implementation of the `set()` method. The record must already be locked before calling this. It
+  // is safe to unlock the record before the returned Promise resolves.
+  async _setLocked(key, value) {
+    // IMPORTANT: This function MUST NOT use the `await` keyword before the entry in `this.buffer`
+    // is added/updated. Using `await` causes execution to return to the caller, and the caller must
+    // be able to immediately unlock the record to avoid unnecessary blocking while the value is
+    // committed to the underlying database. If `await` is used before the entry is updated then the
+    // record will be unlocked prematurely, possibly resulting in inconsistent state.
+    ++this.metrics.writes;
+    try {
+      let entry = this.buffer.get(key);
+      // If there is a write of a different value for the same key already in progress then don't
+      // update the existing entry object -- create a new entry object instead and replace the old
+      // one in this.buffer. (If the existing entry was updated instead, then entry.dirty would
+      // resolve when the old value is committed, not the new value.)
+      if (!entry || entry.writingInProgress) entry = {};
+      else if (entry.dirty) ++this.metrics.writesObsoleted;
+      entry.value = value;
+      // Always mark as dirty even if the value did not change. This simplifies the implementation:
+      // this function doesn't need to perform deep comparisons, and setSub() doesn't need to
+      // perform a deep copy of the object returned from get().
+      if (!entry.dirty) entry.dirty = new SelfContainedPromise();
+      // buffer.set() is called even if the value is unchanged so that the cache entry is marked as
+      // most recently used.
+      this.buffer.set(key, entry);
+      const buffered = this.settings.writeInterval > 0;
+      if (this.logger.isDebugEnabled()) {
+        this.logger.debug(
+            `SET    - ${key} - ${JSON.stringify(value)} - to ${buffered ? 'buffer' : 'database'}`);
+      }
+      // Write it immediately if write buffering is disabled. If write buffering is enabled,
+      // this.flush() will eventually take care of it.
+      if (!buffered) this._write([[key, entry]]); // await is unnecessary.
+      await entry.dirty;
+    } catch (err) {
+      ++this.metrics.writesFailed;
+      throw err;
+    } finally {
+      ++this.metrics.writesFinished;
+    }
+  }
+
+  /**
+   * Sets a subvalue
+   */
+  async setSub(key, sub, value) {
+    if (this.logger.isDebugEnabled()) {
+      this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
+    }
+    let p;
+    await this._lock(key);
+    try {
+      let base;
       try {
-        value = JSON.parse(value);
+        const fullValue = await this._getLocked(key);
+        base = {fullValue};
+        // Emulate a pointer to the property that should be set to `value`.
+        const ptr = {obj: base, prop: 'fullValue'};
+        for (let i = 0; i < sub.length; i++) {
+          let o = ptr.obj[ptr.prop];
+          if (o == null) ptr.obj[ptr.prop] = o = {};
+          // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
+          // ECMAScript automatically wraps primitives in a temporary wrapper object.
+          if (typeof o !== 'object') {
+            throw new TypeError(
+                `Cannot set property ${JSON.stringify(sub[i])} on non-object ` +
+                  `${JSON.stringify(o)} (key: ${JSON.stringify(key)} ` +
+                  `value in db: ${JSON.stringify(fullValue)} ` +
+                  `sub: ${JSON.stringify(sub.slice(0, i + 1))})`);
+          }
+          ptr.obj = ptr.obj[ptr.prop];
+          ptr.prop = sub[i];
+        }
+        ptr.obj[ptr.prop] = value;
       } catch (err) {
-        this.logger.error(`JSON-PROBLEM:${value}`);
+        // this._setLocked() will not be called but it should still count as a write failure.
+        ++this.metrics.writes;
+        ++this.metrics.writesFailed;
+        ++this.metrics.writesFinished;
         throw err;
       }
+      p = this._setLocked(key, base.fullValue);
+    } finally {
+      this._unlock(key);
     }
-
-    // cache the value if caching is enabled
-    if (this.settings.cache > 0) {
-      this.buffer.set(key, {
-        value,
-        dirty: null,
-        writingInProgress: false,
-      });
-    }
-
-    if (this.logger.isDebugEnabled()) {
-      this.logger.debug(`GET    - ${key} - ${JSON.stringify(value)} - from database `);
-    }
-
-    return value;
-  } catch (err) {
-    ++this.metrics.readsFailed;
-    throw err;
-  } finally {
-    ++this.metrics.readsFinished;
+    await p;
   }
-};
 
-/**
- * Find keys function searches the db sets for matching entries and
- * returns the key entries via callback.
- */
-exports.Database.prototype.findKeys = async function (key, notKey) {
-  const bufferKey = `${key}-${notKey}`;
-  const keyValues = await this.wrappedDB.findKeys(key, notKey);
-  if (this.logger.isDebugEnabled()) {
-    this.logger.debug(`GET    - ${bufferKey} - ${JSON.stringify(keyValues)} - from database `);
-  }
-  return keyValues;
-};
-
-/**
- * Remove a record from the database
- */
-exports.Database.prototype.remove = async function (key) {
-  if (this.logger.isDebugEnabled()) this.logger.debug(`DELETE - ${key} - from database `);
-  await this.set(key, null);
-};
-
-/**
- Sets the value trough the wrapper
-*/
-exports.Database.prototype.set = async function (key, value) {
-  await this._lock(key);
-  const p = this._setLocked(key, value);
-  this._unlock(key);
-  await p;
-};
-
-// Implementation of the `set()` method. The record must already be locked before calling this. It
-// is safe to unlock the record before the returned Promise resolves.
-exports.Database.prototype._setLocked = async function (key, value) {
-  // IMPORTANT: This function MUST NOT use the `await` keyword before the entry in `this.buffer` is
-  // added/updated. Using `await` causes execution to return to the caller, and the caller must be
-  // able to immediately unlock the record to avoid unnecessary blocking while the value is
-  // committed to the underlying database. If `await` is used before the entry is updated then the
-  // record will be unlocked prematurely, possibly resulting in inconsistent state.
-  ++this.metrics.writes;
-  try {
-    let entry = this.buffer.get(key);
-    // If there is a write of a different value for the same key already in progress then don't
-    // update the existing entry object -- create a new entry object instead and replace the old one
-    // in this.buffer. (If the existing entry was updated instead, then entry.dirty would resolve
-    // when the old value is committed, not the new value.)
-    if (!entry || entry.writingInProgress) entry = {};
-    else if (entry.dirty) ++this.metrics.writesObsoleted;
-    entry.value = value;
-    // Always mark as dirty even if the value did not change. This simplifies the implementation:
-    // this function doesn't need to perform deep comparisons, and setSub() doesn't need to perform
-    // a deep copy of the object returned from get().
-    if (!entry.dirty) entry.dirty = new SelfContainedPromise();
-    // buffer.set() is called even if the value is unchanged so that the cache entry is marked as
-    // most recently used.
-    this.buffer.set(key, entry);
-    const buffered = this.settings.writeInterval > 0;
-    if (this.logger.isDebugEnabled()) {
-      this.logger.debug(
-          `SET    - ${key} - ${JSON.stringify(value)} - to ${buffered ? 'buffer' : 'database'}`);
-    }
-    // Write it immediately if write buffering is disabled. If write buffering is enabled,
-    // this.flush() will eventually take care of it.
-    if (!buffered) this._write([[key, entry]]); // await is unnecessary.
-    await entry.dirty;
-  } catch (err) {
-    ++this.metrics.writesFailed;
-    throw err;
-  } finally {
-    ++this.metrics.writesFinished;
-  }
-};
-
-/**
- Sets a subvalue
-*/
-exports.Database.prototype.setSub = async function (key, sub, value) {
-  if (this.logger.isDebugEnabled()) {
-    this.logger.debug(`SETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(value)}`);
-  }
-  let p;
-  await this._lock(key);
-  try {
-    let base;
+  /**
+   * Returns a sub value of the object
+   * @param sub is a array, for example if you want to access object.test.bla, the array is ["test",
+   *     "bla"]
+   */
+  async getSub(key, sub) {
+    await this._lock(key);
     try {
-      const fullValue = await this._getLocked(key);
-      base = {fullValue};
-      // Emulate a pointer to the property that should be set to `value`.
-      const ptr = {obj: base, prop: 'fullValue'};
+      // get the full value
+      const value = await this._getLocked(key);
+
+      // everything is correct, navigate to the subvalue and return it
+      let subvalue = value;
+
       for (let i = 0; i < sub.length; i++) {
-        let o = ptr.obj[ptr.prop];
-        if (o == null) ptr.obj[ptr.prop] = o = {};
-        // If o is a primitive (string, number, etc.), then setting `o.foo` has no effect because
-        // ECMAScript automatically wraps primitives in a temporary wrapper object.
-        if (typeof o !== 'object') {
-          throw new TypeError(
-              `Cannot set property ${JSON.stringify(sub[i])} on non-object ${JSON.stringify(o)} ` +
-                `(key: ${JSON.stringify(key)} ` +
-                `value in db: ${JSON.stringify(fullValue)} ` +
-                `sub: ${JSON.stringify(sub.slice(0, i + 1))})`);
+        // test if the subvalue exist
+        if (subvalue != null && subvalue[sub[i]] !== undefined) {
+          subvalue = subvalue[sub[i]];
+        } else {
+          // the subvalue doesn't exist, break the loop and return null
+          subvalue = null;
+          break;
         }
-        ptr.obj = ptr.obj[ptr.prop];
-        ptr.prop = sub[i];
       }
-      ptr.obj[ptr.prop] = value;
-    } catch (err) {
-      // this._setLocked() will not be called but it should still count as a write failure.
-      ++this.metrics.writes;
-      ++this.metrics.writesFailed;
-      ++this.metrics.writesFinished;
-      throw err;
-    }
-    p = this._setLocked(key, base.fullValue);
-  } finally {
-    this._unlock(key);
-  }
-  await p;
-};
 
-/**
- * Returns a sub value of the object
- * @param sub is a array, for example if you want to access object.test.bla, the array is ["test",
- *     "bla"]
- */
-exports.Database.prototype.getSub = async function (key, sub) {
-  await this._lock(key);
-  try {
-    // get the full value
-    const value = await this._getLocked(key);
-
-    // everything is correct, navigate to the subvalue and return it
-    let subvalue = value;
-
-    for (let i = 0; i < sub.length; i++) {
-      // test if the subvalue exist
-      if (subvalue != null && subvalue[sub[i]] !== undefined) {
-        subvalue = subvalue[sub[i]];
-      } else {
-        // the subvalue doesn't exist, break the loop and return null
-        subvalue = null;
-        break;
+      if (this.logger.isDebugEnabled()) {
+        this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
       }
+      return subvalue;
+    } finally {
+      this._unlock(key);
     }
-
-    if (this.logger.isDebugEnabled()) {
-      this.logger.debug(`GETSUB - ${key}${JSON.stringify(sub)} - ${JSON.stringify(subvalue)}`);
-    }
-    return subvalue;
-  } finally {
-    this._unlock(key);
   }
-};
 
-/**
- Writes all dirty values to the database
-*/
-exports.Database.prototype.flush = async function () {
-  if (this._flushDone == null) {
-    this._flushDone = (async () => {
-      while (true) {
-        const dirtyEntries = [];
-        for (const entry of this.buffer) {
-          if (entry[1].dirty && !entry[1].writingInProgress) {
-            dirtyEntries.push(entry);
-            if (this.settings.bulkLimit && dirtyEntries.length >= this.settings.bulkLimit) break;
+  /**
+   * Writes all dirty values to the database
+   */
+  async flush() {
+    if (this._flushDone == null) {
+      this._flushDone = (async () => {
+        while (true) {
+          const dirtyEntries = [];
+          for (const entry of this.buffer) {
+            if (entry[1].dirty && !entry[1].writingInProgress) {
+              dirtyEntries.push(entry);
+              if (this.settings.bulkLimit && dirtyEntries.length >= this.settings.bulkLimit) break;
+            }
           }
+          if (dirtyEntries.length === 0) return;
+          await this._write(dirtyEntries);
         }
-        if (dirtyEntries.length === 0) return;
-        await this._write(dirtyEntries);
-      }
-    })();
+      })();
+    }
+    await this._flushDone;
+    this._flushDone = null;
   }
-  await this._flushDone;
-  this._flushDone = null;
-};
 
-exports.Database.prototype._write = async function (dirtyEntries) {
-  const markDone = (entry, err) => {
-    if (entry.writingInProgress) {
-      entry.writingInProgress = false;
-      if (err != null) ++this.metrics.writesToDbFailed;
-      ++this.metrics.writesToDbFinished;
-    }
-    // If err != null then the entry is still technically dirty, but the responsibility is on the
-    // user to retry failures so from ueberDB's perspective the entry is no longer dirty.
-    entry.dirty.done(err);
-    entry.dirty = null;
-  };
-  const ops = [];
-  const entries = [];
-  for (const [key, entry] of dirtyEntries) {
-    let value = entry.value;
-    try {
-      value = this.settings.json && value != null ? JSON.stringify(value) : clone(value);
-    } catch (err) {
-      markDone(entry, err);
-      continue;
-    }
-    entry.writingInProgress = true;
-    ops.push({type: value == null ? 'remove' : 'set', key, value});
-    entries.push(entry);
-  }
-  if (ops.length === 0) return;
-  this.metrics.writesToDb += ops.length;
-  const writeOneOp = async (op, entry) => {
-    let writeErr = null;
-    try {
-      switch (op.type) {
-        case 'remove':
-          await this.wrappedDB.remove(op.key);
-          break;
-        case 'set':
-          await this.wrappedDB.set(op.key, op.value);
-          break;
-        default:
-          throw new Error(`unsupported operation type: ${op.type}`);
+  async _write(dirtyEntries) {
+    const markDone = (entry, err) => {
+      if (entry.writingInProgress) {
+        entry.writingInProgress = false;
+        if (err != null) ++this.metrics.writesToDbFailed;
+        ++this.metrics.writesToDbFinished;
       }
-    } catch (err) {
-      writeErr = err || new Error(err);
+      // If err != null then the entry is still technically dirty, but the responsibility is on the
+      // user to retry failures so from ueberDB's perspective the entry is no longer dirty.
+      entry.dirty.done(err);
+      entry.dirty = null;
+    };
+    const ops = [];
+    const entries = [];
+    for (const [key, entry] of dirtyEntries) {
+      let value = entry.value;
+      try {
+        value = this.settings.json && value != null ? JSON.stringify(value) : clone(value);
+      } catch (err) {
+        markDone(entry, err);
+        continue;
+      }
+      entry.writingInProgress = true;
+      ops.push({type: value == null ? 'remove' : 'set', key, value});
+      entries.push(entry);
     }
-    markDone(entry, writeErr);
-  };
-  if (ops.length === 1) {
-    await writeOneOp(ops[0], entries[0]);
-  } else {
-    let success = false;
-    try {
-      await this.wrappedDB.doBulk(ops);
-      success = true;
-    } catch (err) {
-      this.logger.error(
-          `Bulk write of ${ops.length} ops failed, retrying individually: ${err.stack || err}`);
-      this.metrics.writesToDbRetried += ops.length;
-      await Promise.all(ops.map(async (op, i) => await writeOneOp(op, entries[i])));
+    if (ops.length === 0) return;
+    this.metrics.writesToDb += ops.length;
+    const writeOneOp = async (op, entry) => {
+      let writeErr = null;
+      try {
+        switch (op.type) {
+          case 'remove':
+            await this.wrappedDB.remove(op.key);
+            break;
+          case 'set':
+            await this.wrappedDB.set(op.key, op.value);
+            break;
+          default:
+            throw new Error(`unsupported operation type: ${op.type}`);
+        }
+      } catch (err) {
+        writeErr = err || new Error(err);
+      }
+      markDone(entry, writeErr);
+    };
+    if (ops.length === 1) {
+      await writeOneOp(ops[0], entries[0]);
+    } else {
+      let success = false;
+      try {
+        await this.wrappedDB.doBulk(ops);
+        success = true;
+      } catch (err) {
+        this.logger.error(
+            `Bulk write of ${ops.length} ops failed, retrying individually: ${err.stack || err}`);
+        this.metrics.writesToDbRetried += ops.length;
+        await Promise.all(ops.map(async (op, i) => await writeOneOp(op, entries[i])));
+      }
+      if (success) entries.forEach((entry) => markDone(entry, null));
     }
-    if (success) entries.forEach((entry) => markDone(entry, null));
+    // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
+    // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
+    // it should be safe to continue using the memory until the next call to this.buffer.set()
+    // evicts the old entries. This saves some CPU cycles at the expense of memory.
   }
-  // At this point we could call db.buffer.evictOld() to ensure that the number of entries in
-  // this.buffer is at or below capacity, but if we haven't run out of memory by this point then
-  // it should be safe to continue using the memory until the next call to this.buffer.set()
-  // evicts the old entries. This saves some CPU cycles at the expense of memory.
 };
 
 const clone = (obj) => {

--- a/lib/CacheAndBufferLayer.js
+++ b/lib/CacheAndBufferLayer.js
@@ -226,21 +226,6 @@ exports.Database = class {
     // start the write Interval
     this.flushInterval = this.settings.writeInterval > 0
       ? setInterval(() => this.flush(), this.settings.writeInterval) : null;
-
-    /**
-     * Adds function to db wrapper for findKey regex.
-     * Used by document dbs like mongodb or dirty.
-     */
-    wrappedDB.createFindRegex = (key, notKey) => {
-      let regex = '';
-      key = key.replace(/\*/g, '.*');
-      regex = `(?=^${key}$)`;
-      if (notKey != null) {
-        notKey = notKey.replace(/\*/g, '.*');
-        regex += `(?!${notKey}$)`;
-      }
-      return new RegExp(regex);
-    };
   }
 
   async _lock(key) {


### PR DESCRIPTION
Multiple commits:
* Use ES6 class syntax for readability
* Derive all database classes from a new AbstractDatabase class
* Move `createFindRegex` to AbstractDatabase
