### PR TITLE
npm i sqlite3 should be run in ./src

### DIFF
--- a/databases/sqlite_db.js
+++ b/databases/sqlite_db.js
@@ -22,7 +22,7 @@ try {
   throw new Error(
       'sqlite3 not found. It was removed from ueberdb\'s dependencies because it requires ' +
       'compilation which fails on several systems. If you still want to use sqlite, run ' +
-      '"npm install sqlite3" in your etherpad-lite root folder.');
+      '"npm install sqlite3" in your etherpad-lite ./src directory.');
 }
 
 const AbstractDatabase = require('../lib/AbstractDatabase');


### PR DESCRIPTION
In theory we could use --no-save, but then after ./bin/run.sh the dependency would be gone again.