### PR TITLE
fixing `set` function bug for deprecated use

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -220,7 +220,7 @@ export const Database = class {
    */
   set(key:string, value:string, cb = null, deprecated = null) {
     if (cb != null) { // @ts-ignore
-      return cbDb.get.call(this.db, key, value, makeDoneCallback(cb, deprecated));
+      return cbDb.set.call(this.db, key, value, makeDoneCallback(cb, deprecated));
     }
     return this.db.set(key, value);
   }


### PR DESCRIPTION
It seems that in the process of refactoring from .js to .ts a bug got created which breaks the deprecated usage of the `set` function. This PR is fixing this problem. 

Its just three letters which got wrong.  `cbDb.get.call` which needed to be `cbDb.set.call` :  https://github.com/ether/ueberDB/blob/main/index.ts#L223 
This creates a misfunction way ahead in some third party etherpad plugin usage (in this case framasoft/ep_mypads ) with the current release of etherpad (1.9.3). 
While etherpad 1.9.1 still uses ueberDB2 (v4.0.11) it works still fine. This was before the refactoring to typescript and in this case the `set` function was still using `cbDb.set.call` as it can be seen here: https://github.com/ether/ueberDB/blob/6919908c289cff4101b4e65fdc0b72c3f95f3605/index.js#L132

would be great if this PR got merged as well as etherpad dependency to ueberDB2 could be updated in the coming etherpad release, so that it is possible to run framasoft/ep_mypads on the latest etherpad relase again. 