### PR TITLE
Fix Regexp match usage in Redis Database

### DIFF
--- a/databases/redis_db.ts
+++ b/databases/redis_db.ts
@@ -59,7 +59,7 @@ export default class RedisDB extends AbstractDatabase {
 
   async findKeys(key:string, notKey:string) {
     if (this._client == null) return null;
-    const [type] = /^([^:*]+):\*$/.exec(key) || [];
+    const [_, type] = /^([^:*]+):\*$/.exec(key) || [];
     if (type != null && ['*:*:*', `${key}:*`].includes(notKey)) {
       // Performance optimization for a common Etherpad case.
       return await this._client.sMembers(`ueberDB:keys:${type}`);


### PR DESCRIPTION
The regexp will return an array of two elements. The first is the total match which is the `key` again. And the second is the actual type we want to search for.

Without this patch etherpad shows no pads after a restart.