### PR TITLE
Fix: include rolldown runtime in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "dist/databases",
     "dist/index.js",
     "dist/*.d.ts",
-    "dist/lib"
+    "dist/lib",
+    "dist/_virtual"
   ],
   "homepage": "https://github.com/ether/ueberDB",
   "scripts": {


### PR DESCRIPTION
The preserveModules build outputs a _virtual/_rolldown/runtime.js file that index.js requires at runtime. The files field in package.json didn't include dist/_virtual/, causing "Cannot find module './_virtual/_rolldown/runtime.js'" when installed from npm.