### PR TITLE
Move core database drivers to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,36 @@
       "name": "Peter Martischka"
     }
   ],
+  "dependencies": {
+    "async": "^3.2.6",
+    "dirty-ts": "^1.1.8",
+    "rusty-store-kv": "^1.3.1",
+    "simple-git": "^3.36.0"
+  },
+  "peerDependencies": {
+    "@elastic/elasticsearch": "^9.3.4",
+    "cassandra-driver": "^4.8.0",
+    "mongodb": "^7.1.1",
+    "mssql": "^12.2.1",
+    "mysql2": "^3.22.0",
+    "nano": "^11.0.5",
+    "pg": "^8.20.0",
+    "redis": "^5.11.0",
+    "rethinkdb": "^2.4.2",
+    "surrealdb": "^2.0.3"
+  },
+  "peerDependenciesMeta": {
+    "@elastic/elasticsearch": { "optional": true },
+    "cassandra-driver": { "optional": true },
+    "mongodb": { "optional": true },
+    "mssql": { "optional": true },
+    "mysql2": { "optional": true },
+    "nano": { "optional": true },
+    "pg": { "optional": true },
+    "redis": { "optional": true },
+    "rethinkdb": { "optional": true },
+    "surrealdb": { "optional": true }
+  },
   "devDependencies": {
     "@elastic/elasticsearch": "^9.3.4",
     "@types/async": "^3.2.25",
@@ -30,10 +60,8 @@
     "@types/pg": "^8.20.0",
     "@types/rethinkdb": "^2.3.21",
     "@types/wtfnode": "^0.10.0",
-    "async": "^3.2.6",
     "cassandra-driver": "^4.8.0",
     "cli-table3": "^0.6.5",
-    "dirty-ts": "^1.1.8",
     "mongodb": "^7.1.1",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
@@ -45,9 +73,7 @@
     "redis": "^5.11.0",
     "rethinkdb": "^2.4.2",
     "rolldown": "^1.0.0-rc.15",
-    "rusty-store-kv": "^1.3.1",
     "semver": "^7.7.4",
-    "simple-git": "^3.36.0",
     "surrealdb": "^2.0.3",
     "testcontainers": "^11.14.0",
     "typescript": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      async:
+        specifier: ^3.2.6
+        version: 3.2.6
+      dirty-ts:
+        specifier: ^1.1.8
+        version: 1.1.8
+      rusty-store-kv:
+        specifier: ^1.3.1
+        version: 1.3.1
+      simple-git:
+        specifier: ^3.36.0
+        version: 3.36.0
     devDependencies:
       '@elastic/elasticsearch':
         specifier: ^9.3.4
@@ -29,18 +42,12 @@ importers:
       '@types/wtfnode':
         specifier: ^0.10.0
         version: 0.10.0
-      async:
-        specifier: ^3.2.6
-        version: 3.2.6
       cassandra-driver:
         specifier: ^4.8.0
         version: 4.8.0
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
-      dirty-ts:
-        specifier: ^1.1.8
-        version: 1.1.8
       mongodb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -74,15 +81,9 @@ importers:
       rolldown:
         specifier: ^1.0.0-rc.15
         version: 1.0.0-rc.15
-      rusty-store-kv:
-        specifier: ^1.3.1
-        version: 1.3.1
       semver:
         specifier: ^7.7.4
         version: 7.7.4
-      simple-git:
-        specifier: ^3.36.0
-        version: 3.36.0
       surrealdb:
         specifier: ^2.0.3
         version: 2.0.3(tslib@2.8.1)(typescript@6.0.2)


### PR DESCRIPTION
## Summary

With the modular build (`preserveModules`), database drivers are loaded at runtime via `dynamic import()`. But all drivers were in `devDependencies`, meaning none were installed in production. This caused `Cannot find module 'dirty-ts'` when Etherpad starts with the default dirty database.

## Changes

**Moved to `dependencies`** (always needed):
- `dirty-ts` — default dev database
- `rusty-store-kv` — default production database + sqlite
- `simple-git` — needed by dirty_git_db
- `async` — needed by mssql, postgres, rethink drivers

**Moved to `peerDependencies` with `optional: true`** (install only what you use):
- cassandra-driver, mongodb, mssql, mysql2, nano, pg, redis, rethinkdb, surrealdb, @elastic/elasticsearch

**Kept in `devDependencies`** (needed for testing all drivers in CI):
- Same packages duplicated so CI can test all backends

## Test plan

- [ ] All 12 database CI tests pass
- [ ] `npm pack --dry-run` shows dependencies in tarball
- [ ] Etherpad starts with default dirty/rusty db without extra installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)