### PR TITLE
ci: modernize dependabot auto-merge (fix broken event filter)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,29 +1,27 @@
-name: Dependabot Automerge
+name: Dependabot auto-merge
+
+on: pull_request
+
 permissions:
   contents: write
   pull-requests: write
-on:
-  workflow_run:
-    workflows:
-      - CI
-    types:
-      - completed
 
 jobs:
   automerge:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Automerge
-        uses: "pascalgn/automerge-action@v0.16.4"
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_METHOD: squash
-          MERGE_LABELS: ""
-          MERGE_RETRY_SLEEP: "100000"
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The existing \`Dependabot Automerge\` workflow has been silently broken. It gates on \`github.event.workflow_run.event == 'push'\`, but Dependabot PRs trigger CI via \`pull_request\` — so that condition is always false and the automerge job has been skipped on every Dependabot PR.

Replaces the workflow with the modern pattern:

- Triggers on \`pull_request\` (the correct event).
- Uses \`dependabot/fetch-metadata@v2\` to classify the update.
- Calls \`gh pr merge --auto --squash\`, which lets GitHub wait on branch-protection required status checks before merging.
- Only patch and minor updates auto-merge. Major updates stay manual (breaking-change risk).

## Prereqs (being applied to the repo alongside this PR)

- \`allow_auto_merge=true\` at the repo level.
- Branch protection on \`main\` with required status checks for the CI \`build\` job and every \`test (<db>)\` matrix job from the Node.js Package workflow, so a Dependabot PR can only auto-merge once the full 10-backend driver suite plus lint/ts-check/build is green.

Without those repo-level settings, \`gh pr merge --auto\` has nothing to wait on and would merge immediately — that would be unsafe.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, next Dependabot patch/minor PR should pick up a \"Dependabot auto-merge\" check that runs, enables auto-merge, and only completes the merge once \`build\` + all \`test (<db>)\` jobs pass.