### PR TITLE
fix(dirty): unwrap CJS default-import for dirty-ts in v6 ESM build

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -16,7 +16,7 @@ jobs:
       # PR ends up red even when only a single integration container is flaky.
       fail-fast: false
       matrix:
-        db: [couch, elasticsearch, mongo, mysql, redis, mock, sqlite, memory, rusty, surrealdb]
+        db: [couch, dirty, elasticsearch, mongo, mysql, redis, mock, sqlite, memory, rusty, surrealdb]
     steps:
       - uses: actions/checkout@v6
 

--- a/databases/dirty_db.ts
+++ b/databases/dirty_db.ts
@@ -22,7 +22,13 @@
 */
 
 import AbstractDatabase, {type Settings} from '../lib/AbstractDatabase';
-import Dirty from 'dirty-ts';
+import DirtyImport from 'dirty-ts';
+
+// dirty-ts is a CJS package that exposes the constructor as `module.exports.default`
+// with the `__esModule` marker. Under Node's ESM-to-CJS interop, the default
+// import resolves to the whole `module.exports` object (not the constructor),
+// so unwrap `.default` if it's present.
+const Dirty: any = (DirtyImport as any).default ?? DirtyImport;
 
 type DirtyDBCallback = (p?:any, keys?: string[])=>{};
 

--- a/databases/dirty_git_db.ts
+++ b/databases/dirty_git_db.ts
@@ -18,7 +18,13 @@ import {simpleGit} from 'simple-git'
  */
 
 
-import Dirty from 'dirty-ts';
+import DirtyImport from 'dirty-ts';
+
+// dirty-ts is a CJS package that exposes the constructor as `module.exports.default`
+// with the `__esModule` marker. Under Node's ESM-to-CJS interop, the default
+// import resolves to the whole `module.exports` object (not the constructor),
+// so unwrap `.default` if it's present.
+const Dirty: any = (DirtyImport as any).default ?? DirtyImport;
 
 export default class extends AbstractDatabase {
   public db: any;


### PR DESCRIPTION
## Summary

- `dirty_db.ts` and `dirty_git_db.ts` do `import Dirty from 'dirty-ts'` and then `new Dirty(...)`. Under v5 this worked because the package was loaded via CommonJS `require`; under v6 the package is pure ESM, and Node's ESM→CJS interop returns the whole `module.exports` object (`{ default: <ctor>, __esModule: true }`) for a default import — so `Dirty` is an object, not a function, and `new Dirty(...)` throws `TypeError: Dirty is not a constructor` at runtime.
- This blocks any consumer of ueberdb2 v6 that uses `dbType: "dirty"` or `dbType: "dirtygit"`. It bit etherpad's Windows CI on https://github.com/ether/etherpad/pull/7734 because `settings.json.template` defaults to `dbType: "dirty"`.
- Fix: read `DirtyImport.default ?? DirtyImport` at module load time, so we get the real constructor in both the current shape and a hypothetical future where dirty-ts is migrated to a true ESM build.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run ts-check`
- [x] `pnpm run build` (rolldown emits `dist/dirty_db-*.js` and `dist/dirty_git_db-*.js` with `const Dirty = DirtyImport.default ?? DirtyImport;`)
- [x] `pnpm exec vitest run test/dirty/` — 80/80 pass
- [x] `pnpm exec vitest run test/dirty/ test/memory/ test/mock/` — 233/233 pass
- [x] Local end-to-end: pack this branch, install into a fresh etherpad checkout, run `pnpm test` with `dbType: "dirty"` — 1115/1115 backend tests pass (was: `TypeError: Dirty is not a constructor` immediately on init)

## Suggested follow-up

Tag a v6.0.3 release after merge so dependabot can pick this up in https://github.com/ether/etherpad/pull/7734 (or its successor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)