### PR TITLE
chore: add prepare script so git installs build dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "build": "pnpm run build:js && pnpm run build:types",
+    "prepare": "pnpm run build",
     "build:js": "pnpm exec rolldown -c rolldown.config.mjs",
     "build:types": "pnpm exec tsc --emitDeclarationOnly",
     "test": "vitest --test-timeout=120000",


### PR DESCRIPTION
## Summary
- One-line addition of \`prepare: pnpm run build\` so consumers installing via a git ref (e.g. \`pnpm add github:ether/ueberDB#main\`) get \`dist/\` built automatically
- No effect on the npm-tarball install path — \`prepare\` doesn't run when installing a published tarball
- Picked up while unblocking ether/etherpad#7831, whose CI is stuck on \`ueberdb2 ^6.1.0\` because the publish workflow on this repo has been failing E404 since #981 merged (separate issue — NPM_TOKEN auth)

## Test plan
- [x] Diff is one line; no test surface
- Once merged, etherpad#7831 can pin \`github:ether/ueberDB#main\` to get green CI without waiting for the publish workflow to be repaired

🤖 Generated with [Claude Code](https://claude.com/claude-code)