### PR TITLE
fix(redis): attach client error handler so a dropped connection doesn't crash the process

### DIFF
--- a/databases/redis_db.ts
+++ b/databases/redis_db.ts
@@ -59,7 +59,9 @@ export default class RedisDB extends AbstractDatabase {
       // reconnects. Attached before connect() so connect-time failures are
       // covered too.
       this._client.on("error", (err: Error) => {
-        this.logger.error(`Redis client error (will reconnect): ${err.stack || err}`);
+        // Don't claim reconnection is guaranteed — node-redis reconnects for
+        // transient socket errors but not for terminal/shutdown ones.
+        this.logger.error(`Redis client error: ${err?.stack || err}`);
       });
       await this._client.connect();
       await this._client.ping();

--- a/databases/redis_db.ts
+++ b/databases/redis_db.ts
@@ -50,6 +50,17 @@ export default class RedisDB extends AbstractDatabase {
       this._client = createClient(options);
     }
     if (this._client) {
+      // node-redis re-emits connection/socket errors (idle drop, server
+      // restart, failover, a proxy closing the connection) on the client as
+      // an EventEmitter 'error'. With no listener Node treats it as uncaught
+      // and terminates the host process — and node-redis also won't begin
+      // reconnecting. The official client docs require attaching this
+      // listener; with it, the error is logged and the client transparently
+      // reconnects. Attached before connect() so connect-time failures are
+      // covered too.
+      this._client.on("error", (err: Error) => {
+        this.logger.error(`Redis client error (will reconnect): ${err.stack || err}`);
+      });
       await this._client.connect();
       await this._client.ping();
     }

--- a/test/redis/connection-drop.spec.ts
+++ b/test/redis/connection-drop.spec.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import * as ueberdb from "../../index";
 import { createClient } from "redis";
@@ -36,6 +36,12 @@ describe("redis connection-drop recovery", () => {
 
   afterAll(async () => {
     if (container) await container.stop();
+  });
+
+  // Clear per attempt: vitest is configured with retries, and a stale entry
+  // from a previous attempt must not satisfy this run's "handler fired" check.
+  beforeEach(() => {
+    loggedErrors.length = 0;
   });
 
   it("survives its connection being killed and recovers", async () => {

--- a/test/redis/connection-drop.spec.ts
+++ b/test/redis/connection-drop.spec.ts
@@ -55,20 +55,43 @@ describe("redis connection-drop recovery", () => {
       // (default yes) means the admin's own connection is spared.
       const admin = createClient({ socket: { host, port } });
       await admin.connect();
-      await admin.sendCommand(["CLIENT", "KILL", "TYPE", "normal"]);
-      await admin.quit();
+      try {
+        await admin.sendCommand(["CLIENT", "KILL", "TYPE", "normal"]);
+      } finally {
+        await admin.quit().catch(() => admin.destroy?.());
+      }
 
-      // Allow the 'error' event to fire and the client to reconnect.
-      await new Promise((r) => setTimeout(r, 1000));
+      // Wait — with a bounded poll rather than a fixed sleep — for the client
+      // to recover (node-redis reconnects after the dropped socket). The
+      // round-trip succeeds as soon as recovery happens; it only fails on a
+      // real timeout, so this is deterministic rather than race-prone.
+      await waitFor(async () => {
+        await db.set("dropkey", "after");
+        return (await db.get("dropkey")) === "after";
+      }, 30000);
 
       // 1) The handler caught the dropped-connection error (proves the fix ran).
       expect(loggedErrors.some((m) => /Redis client error/.test(m))).toBe(true);
-
-      // 2) The client recovered: a fresh round-trip works.
-      await db.set("dropkey", "after");
+      // 2) The client recovered (asserted again for an explicit signal).
       expect(await db.get("dropkey")).toBe("after");
     } finally {
       await db.close();
     }
   }, 60000);
 });
+
+// Poll an async predicate until it returns true or the deadline passes.
+// Errors from the predicate are treated as "not ready yet" and retried.
+async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      if (await predicate()) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms${lastErr ? `: ${lastErr}` : ""}`);
+}

--- a/test/redis/connection-drop.spec.ts
+++ b/test/redis/connection-drop.spec.ts
@@ -87,17 +87,21 @@ describe("redis connection-drop recovery", () => {
 });
 
 // Poll an async predicate until it returns true or the deadline passes.
-// Errors from the predicate are treated as "not ready yet" and retried.
+// Errors from the predicate are treated as "not ready yet" and retried; the
+// most recent one is surfaced (with its stack) if we time out.
 async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number) {
   const deadline = Date.now() + timeoutMs;
   let lastErr: unknown;
   while (Date.now() < deadline) {
     try {
       if (await predicate()) return;
+      lastErr = undefined; // a clean (but not-yet-true) attempt clears stale errors
     } catch (err) {
       lastErr = err;
     }
     await new Promise((r) => setTimeout(r, 200));
   }
-  throw new Error(`waitFor timed out after ${timeoutMs}ms${lastErr ? `: ${lastErr}` : ""}`);
+  const detail =
+    lastErr instanceof Error ? (lastErr.stack ?? lastErr.message) : String(lastErr ?? "");
+  throw new Error(`waitFor timed out after ${timeoutMs}ms${detail ? `: ${detail}` : ""}`);
 }

--- a/test/redis/connection-drop.spec.ts
+++ b/test/redis/connection-drop.spec.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import * as ueberdb from "../../index";
+import { createClient } from "redis";
+
+// Behavioural regression test for the redis client error handler.
+//
+// node-redis emits connection/socket errors as an EventEmitter 'error'.
+// WITHOUT a listener Node treats it as uncaught and crashes the process (and
+// node-redis won't reconnect). This test warms the client, then kills its
+// connection server-side with CLIENT KILL (what a failover / proxy idle
+// timeout does), and asserts the handler caught it and the client recovered.
+//
+// Verified locally that this FAILS if the client.on('error', …) handler is
+// removed from redis_db.ts (the dropped-socket error becomes uncaught and
+// kills the worker) and PASSES with it.
+describe("redis connection-drop recovery", () => {
+  let container: StartedTestContainer;
+  let host: string;
+  let port: number;
+  const loggedErrors: string[] = [];
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (msg: string) => loggedErrors.push(String(msg)),
+  };
+
+  beforeAll(async () => {
+    // Dynamic mapped port so this is safe to run alongside the other redis
+    // spec (which binds 6379) and in CI without conflicts.
+    container = await new GenericContainer("redis:bookworm").withExposedPorts(6379).start();
+    host = container.getHost();
+    port = container.getMappedPort(6379);
+  }, 120000);
+
+  afterAll(async () => {
+    if (container) await container.stop();
+  });
+
+  it("survives its connection being killed and recovers", async () => {
+    const db = new ueberdb.Database(
+      "redis",
+      { host, port },
+      { cache: 0, writeInterval: 0 },
+      logger,
+    );
+    await db.init();
+
+    try {
+      await db.set("dropkey", "before");
+      expect(await db.get("dropkey")).toBe("before");
+
+      // Kill the driver's connection from a separate admin client. SKIPME
+      // (default yes) means the admin's own connection is spared.
+      const admin = createClient({ socket: { host, port } });
+      await admin.connect();
+      await admin.sendCommand(["CLIENT", "KILL", "TYPE", "normal"]);
+      await admin.quit();
+
+      // Allow the 'error' event to fire and the client to reconnect.
+      await new Promise((r) => setTimeout(r, 1000));
+
+      // 1) The handler caught the dropped-connection error (proves the fix ran).
+      expect(loggedErrors.some((m) => /Redis client error/.test(m))).toBe(true);
+
+      // 2) The client recovered: a fresh round-trip works.
+      await db.set("dropkey", "after");
+      expect(await db.get("dropkey")).toBe("after");
+    } finally {
+      await db.close();
+    }
+  }, 60000);
+});


### PR DESCRIPTION
## Problem

The redis analogue of ether/etherpad#7878 (postgres, PR #998). node-redis re-emits connection/socket errors — an idle drop, server restart, failover, or a proxy/LB/firewall closing the connection — on the client as an EventEmitter `'error'`. **With no listener, Node treats it as an uncaught exception and terminates the host process**, and node-redis additionally **won't start reconnecting**. The [official node-redis error-handling docs](https://redis.io/docs/latest/develop/clients/nodejs/error-handling/) require attaching this listener; `redis_db.ts` never did, so any of those events crashed Etherpad.

## Fix

Attach `client.on('error', …)` in `init()` **before** `connect()` (so connect-time failures are covered too): log the error and let node-redis transparently reconnect.

## Test (real, not a wiring assertion)

`test/redis/connection-drop.spec.ts` starts a redis container, warms the client, then kills its connection server-side with `CLIENT KILL TYPE normal` — exactly what a failover or a proxy idle-timeout does — and asserts:
1. the handler caught the error (proves the fix ran), and
2. the client recovered (a subsequent round-trip works).

Verified locally that this **fails without the handler** (node-redis can't reconnect, so the recovery query hangs to a timeout) and **passes with it**. redis is already in the container `test` matrix, so this runs in CI under `pnpm run test redis` (the new spec uses a dynamic mapped port, so it doesn't collide with the existing fixed-6379 redis spec).

## Verification
- `pnpm run lint` / `format:check` / `ts-check` / `build` — clean
- `vitest run test/redis/connection-drop.spec.ts` — passes with fix, fails (timeout) without

## Context
Part of a per-driver sweep prompted by #998. Each affected backend gets its own PR (no combined PR). postgres = #998; mysql to follow; mongodb/cassandra/elasticsearch/couch and the local stores are not affected; rethink/surrealdb still under review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)