### PR TITLE
test: guard that an open Database keeps the host event loop alive

### DIFF
--- a/test/mock/keepalive-child.ts
+++ b/test/mock/keepalive-child.ts
@@ -1,0 +1,35 @@
+// Child process for ./test_event_loop_keepalive.spec.ts.
+//
+// Opens a Database and then goes completely idle. It deliberately does NOT
+// arm any keepalive of its own: it even unref()'s its stdio so that the ONLY
+// thing capable of keeping this process's event loop alive is ueberdb's
+// internal flush machinery. If an open Database stops anchoring the loop, node
+// has nothing left to do and exits 0 right here -- which is the regression the
+// parent spec asserts against.
+//
+// Run via: node --import ../../benchmarks/register-ts.mjs keepalive-child.ts
+// (the register-ts hook loads the TS source graph with no build step).
+
+import * as ueberdb from "../../index";
+import { ConsoleLogger } from "../../lib/logging";
+
+// writeInterval > 0 is the realistic production config (Etherpad uses 100ms).
+// The "mock" driver holds no handles of its own, so it isolates the cache
+// layer's loop-anchoring behaviour from any per-driver socket/file handle.
+const db = new ueberdb.Database(
+  "mock",
+  {},
+  { writeInterval: 100, json: false },
+  new ConsoleLogger(),
+);
+
+await db.init();
+
+process.stdout.write("READY\n");
+
+// Drop every handle this process owns. A piped stdout/stderr (or an IPC
+// channel, if the parent used fork) is itself a referenced handle that would
+// keep the loop alive and mask the bug. After this, only ueberdb can.
+process.stdout.unref?.();
+process.stderr.unref?.();
+(process as unknown as { channel?: { unref?: () => void } }).channel?.unref?.();

--- a/test/mock/test_event_loop_keepalive.spec.ts
+++ b/test/mock/test_event_loop_keepalive.spec.ts
@@ -1,0 +1,84 @@
+// Regression test: an *open* Database must keep the host process's event loop
+// alive (until close()).
+//
+// For years ueberdb's cache layer created an always-on, *referenced*
+// `setInterval` flush timer in its constructor, which had the side effect of
+// anchoring the host event loop for as long as the Database was open.
+// Consumers (e.g. Etherpad) relied on this implicitly: during the window
+// between "DB initialised" and "HTTP server listening" nothing else holds the
+// loop open, so if ueberdb stops anchoring it, node's loop drains and the
+// process exits 0 *mid-startup* -- before it can bind a port or serve traffic.
+//
+// A later cache-layer rewrite replaced that referenced `setInterval` with a
+// lazily-armed, `.unref()`'d `setTimeout` that only exists while there are
+// dirty keys. On a freshly-opened, write-free Database there are no dirty keys,
+// so no timer is armed and the anchoring behaviour silently disappeared --
+// turning a downstream production boot into a clean early exit.
+//
+// This must be checked in a SEPARATE process: a same-process test runner keeps
+// its own event loop alive, so it can never observe the loop draining. The
+// child opens a Database, goes idle, and unref()'s its own stdio; if the open
+// Database keeps the loop alive the child stays running, otherwise it exits 0.
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe(__filename, () => {
+  it("keeps the host event loop alive while open (no silent early exit after init)", async () => {
+    const registerTs = pathToFileURL(
+      path.join(__dirname, "..", "..", "benchmarks", "register-ts.mjs"),
+    ).href;
+    const childPath = path.join(__dirname, "keepalive-child.ts");
+
+    const proc = spawn(process.execPath, ["--import", registerTs, childPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    proc.stdout.on("data", (d) => (output += d.toString()));
+    proc.stderr.on("data", (d) => (output += d.toString()));
+
+    // Attach the exit listener immediately (before any await) so an exit that
+    // happens between "init done" and the survival check below is never missed.
+    let exitInfo: { code: number | null; signal: string | null } | null = null;
+    const exited = new Promise<void>((resolve) =>
+      proc.on("exit", (code, signal) => {
+        exitInfo = { code, signal };
+        resolve();
+      }),
+    );
+
+    // 1) Wait for the child to finish init (prints READY) -- or die trying.
+    //    A child that dies before READY is a genuine init failure, reported here.
+    await Promise.race([
+      (async () => {
+        while (!output.includes("READY") && exitInfo == null) await sleep(50);
+      })(),
+      sleep(15000),
+    ]);
+    expect(
+      output,
+      `child never reached READY (Database init failed or process died early):\n${output}`,
+    ).toContain("READY");
+
+    // 2) Now that it is open and idle, it MUST stay alive. With the regression
+    //    (unref'd flush timer + no dirty keys) the loop drains and it exits 0.
+    const fate = await Promise.race([
+      exited.then(() => "exited" as const),
+      sleep(3000).then(() => "alive" as const),
+    ]);
+    proc.kill("SIGKILL");
+
+    expect(
+      fate,
+      "An open Database stopped anchoring the event loop: the child process " +
+        `exited on its own after init (${JSON.stringify(exitInfo)}). This is the ` +
+        "unref'd-flush-timer regression that lets a consumer exit mid-startup " +
+        `before it can bind/serve.\n${output}`,
+    ).toBe("alive");
+  });
+});


### PR DESCRIPTION
## What

Adds a regression test (`test/lifecycle/keepalive.spec.ts` + `keepalive-child.ts`) asserting that an **open `Database` keeps the host process's event loop alive** until `close()`.

> ⚠️ **This test is RED on `main`** — the regression is present. It is intentionally **test-only (no fix)** to lock in the contract. It goes green once the cache layer restores a referenced keepalive (released on `close()`).

## Why

For years `CacheAndBufferLayer` created an always-on, **referenced** `setInterval` flush timer in its constructor. A side effect: it anchored the host event loop for as long as a `Database` was open. Consumers relied on this implicitly — most importantly **Etherpad**, whose startup has a window between "DB initialised" and "HTTP server listening" where nothing else holds the loop open.

The cache-layer perf rewrite replaced that referenced `setInterval` with a lazily-armed, **`.unref()`'d** `setTimeout` that only exists while there are dirty keys (`_scheduleFlush`, lib/CacheAndBufferLayer.ts). On a freshly-opened, write-free `Database` there are **no dirty keys → no timer is armed → the loop is no longer anchored**. The consumer's process then drains its event loop and **exits 0 mid-startup**, before it can bind/serve.

This is exactly what broke Etherpad's packaged (`.deb`/systemd) boot — the service logged its version banner then `Deactivated successfully`, and `/health` never came up. Etherpad has pinned `ueberdb2` back to `6.1.9` as a stopgap (ether/etherpad#7969); this test is the upstream guard so the behaviour can't silently regress again.

## How the test works

- **Separate process is mandatory.** A same-process test runner keeps its own event loop alive, so it can *never* observe the loop draining. The spec spawns a child.
- The child opens a `mock` Database (`writeInterval: 100`, no writes), prints `READY`, then **unref's its own stdio** so that ueberdb's flush machinery is the *only* thing that can keep it alive.
- The parent asserts the child **stays running** for a window rather than exiting on its own. With the regression it exits `0` right after init; the assertion reports that precisely.
- The child loads the TS source graph with **no build step** via the existing `benchmarks/register-ts.mjs` hook.

Verified locally on Node 24: **fails on `main`**, and **passes** when a referenced keepalive (cleared on `close()`) is restored to the cache layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)